### PR TITLE
gql2go,graphql: Add support for recursive input types via init loading

### DIFF
--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -147,6 +147,13 @@ func (def *InputValueDefinition) GetLoc() Location {
 	return def.Loc
 }
 
+func (def *InputValueDefinition) String() string {
+	if def.Name != nil {
+		return def.Name.Value
+	}
+	return "InputValueDefinition"
+}
+
 // InterfaceDefinition implements Node, Definition
 type InterfaceDefinition struct {
 	Loc        Location


### PR DESCRIPTION
Example use case

```
input WorkflowNodeInput {
  name: String!
  action: WorkflowNodeActionInput!
  children: [WorkflowNodeRelationshipInput]!
  triggers: [WorkflowNodeTriggerInput!]!
}

input WorkflowNodeRelationshipInput {
  child: WorkflowNodeInput!
  continuationType: WorkflowNodeRelationshipContinuationType!
}
```