### PR TITLE
gqldecode: fix compound emojis

### DIFF
--- a/gqldecode/unicode.go
+++ b/gqldecode/unicode.go
@@ -19,10 +19,7 @@ func IsValidPlane0Unicode(s string) bool {
 }
 
 var unicodeSanitizeReplacer = strings.NewReplacer(
-	string('\u200B'), "", // zero-width space
-	string('\uFEFF'), "", // zero-width no-break space
-	string('\u200D'), "", // zero-width joiner
-	string('\u200C'), "", // zero-width non-joiner
+	"\uFEFF", "", // zero-width no-break space (though really now only a byte order marker)
 )
 
 func sanitizeUnicode(s string) string {

--- a/gqldecode/unicode_test.go
+++ b/gqldecode/unicode_test.go
@@ -12,3 +12,16 @@ func TestIsValidPlane0Unicode(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestSanitizeUnicode(t *testing.T) {
+	cases := map[string]string{
+		"foo":    "foo",
+		"🤦‍♀️":   "🤦‍♀️",
+		"\uFEFF": "", // zero-width no-break space
+	}
+	for in, exp := range cases {
+		if out := sanitizeUnicode(in); out != exp {
+			t.Errorf("sanitizeUnicode(%q) = %q, expected %q", in, out, exp)
+		}
+	}
+}


### PR DESCRIPTION
Only filter out \ufeff (zero-width no-break space though really just a byte order marker now). \u200d specifically broke compound emojis.