### PR TITLE
Move context to function calls rather than param structs

### DIFF
--- a/abstract_test.go
+++ b/abstract_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -47,7 +48,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Name, nil
 					}
@@ -56,7 +57,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			},
 			"woofs": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Woofs, nil
 					}
@@ -78,7 +79,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Fields: graphql.Fields{
 			"name": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Name, nil
 					}
@@ -87,7 +88,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			},
 			"meows": &graphql.Field{
 				Type: graphql.Boolean,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Meows, nil
 					}
@@ -102,7 +103,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
@@ -145,7 +146,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Errors: nil,
 	}
 
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -202,7 +203,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
@@ -245,7 +246,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 		Errors: nil,
 	}
 
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -269,7 +270,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 				Type: graphql.String,
 			},
 		},
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			if _, ok := p.Value.(*testCat); ok {
 				return catType
 			}
@@ -325,7 +326,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
@@ -376,7 +377,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		},
 	}
 
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -425,7 +426,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 		Types: []*graphql.Object{
 			dogType, catType,
 		},
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			if _, ok := p.Value.(*testCat); ok {
 				return catType
 			}
@@ -444,7 +445,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			Fields: graphql.Fields{
 				"pets": &graphql.Field{
 					Type: graphql.NewList(petType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
@@ -495,7 +496,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 		},
 	}
 
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})

--- a/cmd/graphql2go/main.go
+++ b/cmd/graphql2go/main.go
@@ -856,10 +856,10 @@ func (g *generator) renderFieldDefinition(objName string, def *ast.FieldDefiniti
 			assertionType = "map[string]interface{}"
 		}
 		lines = append(lines,
-			fmt.Sprintf("%s\tResolve: func(p graphql.ResolveParams) (interface{}, error) {", indent),
+			fmt.Sprintf("%s\tResolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {", indent),
 			fmt.Sprintf("%s\t\tr := p.Info.RootValue.(map[string]interface{})[%s].(%s)", indent, goObjName+"ResolversKey", goObjName+"Resolvers"))
 		if len(def.Arguments) == 0 {
-			lines = append(lines, fmt.Sprintf("%s\t\treturn r.%s(p.Context, p.Source.(%s), p)", indent, goFieldName, assertionType))
+			lines = append(lines, fmt.Sprintf("%s\t\treturn r.%s(ctx, p.Source.(%s), p)", indent, goFieldName, assertionType))
 		} else {
 			lines = append(lines,
 				fmt.Sprintf("%s\t\tvar args %s%sArgs", indent, goObjName, goFieldName),
@@ -875,7 +875,7 @@ func (g *generator) renderFieldDefinition(objName string, def *ast.FieldDefiniti
 				fmt.Sprintf("%s\t\t\t}", indent),
 				fmt.Sprintf("%s\t\t\treturn nil, err", indent),
 				fmt.Sprintf("%s\t\t}", indent),
-				fmt.Sprintf("%s\t\treturn r.%s(p.Context, p.Source.(%s), &args, p)", indent, goFieldName, assertionType))
+				fmt.Sprintf("%s\t\treturn r.%s(ctx, p.Source.(%s), &args, p)", indent, goFieldName, assertionType))
 		}
 		lines = append(lines, fmt.Sprintf("%s\t},", indent))
 	}

--- a/definition.go
+++ b/definition.go
@@ -1,13 +1,12 @@
 package graphql
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"regexp"
 	"sync"
 	"sync/atomic"
-
-	"context"
 
 	"github.com/sprucehealth/graphql/gqlerrors"
 	"github.com/sprucehealth/graphql/language/ast"
@@ -375,11 +374,6 @@ type IsTypeOfParams struct {
 
 	// Info is a collection of information about the current execution state.
 	Info ResolveInfo
-
-	// Context argument is a context value that is provided to every resolve function within an execution.
-	// It is commonly
-	// used to represent an authenticated user, or request-specific caches.
-	Context context.Context
 }
 
 type IsTypeOfFn func(p IsTypeOfParams) bool
@@ -592,14 +586,9 @@ type ResolveParams struct {
 
 	// Info is a collection of information about the current execution state.
 	Info ResolveInfo
-
-	// Context argument is a context value that is provided to every resolve function within an execution.
-	// It is commonly
-	// used to represent an authenticated user, or request-specific caches.
-	Context context.Context
 }
 
-type FieldResolveFn func(p ResolveParams) (interface{}, error)
+type FieldResolveFn func(ctx context.Context, p ResolveParams) (interface{}, error)
 
 type ResolveInfo struct {
 	FieldName      string
@@ -715,14 +704,9 @@ type ResolveTypeParams struct {
 
 	// Info is a collection of information about the current execution state.
 	Info ResolveInfo
-
-	// Context argument is a context value that is provided to every resolve function within an execution.
-	// It is commonly
-	// used to represent an authenticated user, or request-specific caches.
-	Context context.Context
 }
 
-type ResolveTypeFn func(p ResolveTypeParams) *Object
+type ResolveTypeFn func(ctx context.Context, p ResolveTypeParams) *Object
 
 func NewInterface(config InterfaceConfig) *Interface {
 	it := &Interface{

--- a/directives_test.go
+++ b/directives_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -37,7 +38,7 @@ func executeDirectivesTestQuery(t *testing.T, doc string) *graphql.Result {
 		AST:    ast,
 		Root:   directivesTestData,
 	}
-	return testutil.TestExecute(t, ep)
+	return testutil.TestExecute(t, context.Background(), ep)
 }
 
 func TestDirectives_DirectivesMustBeNamed(t *testing.T) {

--- a/enum_type_test.go
+++ b/enum_type_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -40,7 +41,7 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.String,
 				},
 			},
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 				if fromInt, ok := p.Args["fromInt"]; ok {
 					return fromInt, nil
 				}
@@ -63,7 +64,7 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 					Type: graphql.Int,
 				},
 			},
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 				if fromInt, ok := p.Args["fromInt"]; ok {
 					return fromInt, nil
 				}
@@ -85,7 +86,7 @@ var enumTypeTestMutationType = graphql.NewObject(graphql.ObjectConfig{
 					Type: enumTypeTestColorType,
 				},
 			},
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 				if color, ok := p.Args["color"]; ok {
 					return color, nil
 				}
@@ -105,7 +106,7 @@ var enumTypeTestSubscriptionType = graphql.NewObject(graphql.ObjectConfig{
 					Type: enumTypeTestColorType,
 				},
 			},
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 				if color, ok := p.Args["color"]; ok {
 					return color, nil
 				}
@@ -122,14 +123,14 @@ var enumTypeTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 })
 
 func executeEnumTypeTest(query string) *graphql.Result {
-	return g(graphql.Params{
+	return graphql.Do(context.Background(), graphql.Params{
 		Schema:        enumTypeTestSchema,
 		RequestString: query,
 	})
 }
 
 func executeEnumTypeTestWithParams(query string, params map[string]interface{}) *graphql.Result {
-	return g(graphql.Params{
+	return graphql.Do(context.Background(), graphql.Params{
 		Schema:         enumTypeTestSchema,
 		RequestString:  query,
 		VariableValues: params,

--- a/examples/context/main.go
+++ b/examples/context/main.go
@@ -33,8 +33,8 @@ var queryType = graphql.NewObject(
 		Fields: graphql.Fields{
 			"me": &graphql.Field{
 				Type: userType,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					return p.Context.Value("currentUser"), nil
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
+					return ctx.Value("currentUser"), nil
 				},
 			},
 		},
@@ -45,10 +45,9 @@ func graphqlHandler(w http.ResponseWriter, r *http.Request) {
 		ID   int    `json:"id"`
 		Name string `json:"name"`
 	}{1, "cool user"}
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.WithValue(r.Context(), "currentUser", user), graphql.Params{
 		Schema:        Schema,
 		RequestString: r.URL.Query()["query"][0],
-		Context:       context.WithValue(context.Background(), "currentUser", user),
 	})
 	if len(result.Errors) > 0 {
 		log.Printf("wrong result, unexpected errors: %v", result.Errors)

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -13,7 +14,7 @@ func main() {
 	fields := graphql.Fields{
 		"hello": &graphql.Field{
 			Type: graphql.String,
-			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 				return "world", nil
 			},
 		},
@@ -32,7 +33,7 @@ func main() {
 		}
 	`
 	params := graphql.Params{Schema: schema, RequestString: query}
-	r := graphql.Do(params)
+	r := graphql.Do(context.Background(), params)
 	if len(r.Errors) > 0 {
 		log.Fatalf("failed to execute graphql operation, errors: %+v", r.Errors)
 	}

--- a/examples/star-wars/main.go
+++ b/examples/star-wars/main.go
@@ -12,13 +12,13 @@ import (
 func main() {
 	http.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query()["query"][0]
-		result := graphql.Do(graphql.Params{
+		result := graphql.Do(r.Context(), graphql.Params{
 			Schema:        testutil.StarWarsSchema,
 			RequestString: query,
 		})
-		json.NewEncoder(w).Encode(result)
+		_ = json.NewEncoder(w).Encode(result)
 	})
 	fmt.Println("Now server is running on port 8080")
 	fmt.Println("Test with Get      : curl -g 'http://localhost:8080/graphql?query={hero{name}}'")
-	http.ListenAndServe(":8080", nil)
+	_ = http.ListenAndServe(":8080", nil)
 }

--- a/executor_bench_test.go
+++ b/executor_bench_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sprucehealth/graphql/language/parser"
@@ -24,7 +25,7 @@ func TestDefaultResolveFn(t *testing.T) {
 			FieldName: "F",
 		},
 	}
-	v, err := defaultResolveFn(p)
+	v, err := defaultResolveFn(context.Background(), p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +50,7 @@ func TestDefaultResolveFn(t *testing.T) {
 			FieldName: "F",
 		},
 	}
-	v, err = defaultResolveFn(p)
+	v, err = defaultResolveFn(context.Background(), p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +61,7 @@ func TestDefaultResolveFn(t *testing.T) {
 	}
 
 	p.Info.FieldName = "G"
-	v, err = defaultResolveFn(p)
+	v, err = defaultResolveFn(context.Background(), p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +94,7 @@ func BenchmarkDefaultResolveFnStruct(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := defaultResolveFn(p); err != nil {
+		if _, err := defaultResolveFn(context.Background(), p); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -119,7 +120,7 @@ func BenchmarkDefaultResolveFnMap(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := defaultResolveFn(p); err != nil {
+		if _, err := defaultResolveFn(context.Background(), p); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -145,37 +146,37 @@ func BenchmarkQuery(b *testing.B) {
 			Fields: Fields{
 				"foo": &Field{
 					Type: NewNonNull(enumType),
-					Resolve: func(p ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 						return enumValue, nil
 					},
 				},
 				"someID": &Field{
 					Type: NewNonNull(ID),
-					Resolve: func(p ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 						return "abc", nil
 					},
 				},
 				"someString": &Field{
 					Type: NewNonNull(String),
-					Resolve: func(p ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 						return "bar", nil
 					},
 				},
 				"someInt": &Field{
 					Type: NewNonNull(Int),
-					Resolve: func(p ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 						return 123, nil
 					},
 				},
 				"someFloat": &Field{
 					Type: NewNonNull(Float),
-					Resolve: func(p ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 						return 1.23, nil
 					},
 				},
 				"someBoolean": &Field{
 					Type: NewNonNull(Boolean),
-					Resolve: func(p ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 						return true, nil
 					},
 				},
@@ -211,7 +212,7 @@ func BenchmarkQuery(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		result := Execute(ep)
+		result := Execute(context.Background(), ep)
 		if len(result.Errors) > 0 {
 			b.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 		}

--- a/executor_resolve_test.go
+++ b/executor_resolve_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -35,7 +36,7 @@ func TestExecutesResolveFunction_DefaultFunctionAccessesProperties(t *testing.T)
 		"test": "testValue",
 	}
 
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: `{ test }`,
 		RootObject:    source,
@@ -58,7 +59,7 @@ func TestExecutesResolveFunction_DefaultFunctionCallsMethods(t *testing.T) {
 		"test": "testValue",
 	}
 
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: `{ test }`,
 		RootObject:    source,
@@ -75,7 +76,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction(t *testing.T) {
 			"aStr": &graphql.ArgumentConfig{Type: graphql.String},
 			"aInt": &graphql.ArgumentConfig{Type: graphql.Int},
 		},
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 			b, err := json.Marshal(p.Args)
 			return string(b), err
 		},
@@ -84,7 +85,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction(t *testing.T) {
 	expected := map[string]interface{}{
 		"test": "{}",
 	}
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: `{ test }`,
 	})
@@ -95,7 +96,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction(t *testing.T) {
 	expected = map[string]interface{}{
 		"test": `{"aStr":"String!"}`,
 	}
-	result = graphql.Do(graphql.Params{
+	result = graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: `{ test(aStr: "String!") }`,
 	})
@@ -106,7 +107,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction(t *testing.T) {
 	expected = map[string]interface{}{
 		"test": `{"aInt":-123,"aStr":"String!"}`,
 	}
-	result = graphql.Do(graphql.Params{
+	result = graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: `{ test(aInt: -123, aStr: "String!") }`,
 	})
@@ -116,7 +117,6 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction(t *testing.T) {
 }
 
 func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_WithoutJSONTags(t *testing.T) {
-
 	// For structs without JSON tags, it will map to upper-cased exported field names
 	type SubObjectWithoutJSONTags struct {
 		Str string
@@ -136,7 +136,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 			"aStr": &graphql.ArgumentConfig{Type: graphql.String},
 			"aInt": &graphql.ArgumentConfig{Type: graphql.Int},
 		},
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 			aStr, _ := p.Args["aStr"].(string)
 			aInt, _ := p.Args["aInt"].(int)
 			return &SubObjectWithoutJSONTags{
@@ -152,7 +152,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 			"Int": 0,
 		},
 	}
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: `{ test { Str, Int } }`,
 	})
@@ -167,7 +167,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 			"Int": 0,
 		},
 	}
-	result = graphql.Do(graphql.Params{
+	result = graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: `{ test(aStr: "String!") { Str, Int } }`,
 	})
@@ -181,7 +181,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 			"Int": -123,
 		},
 	}
-	result = graphql.Do(graphql.Params{
+	result = graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: `{ test(aInt: -123, aStr: "String!") { Str, Int } }`,
 	})
@@ -212,7 +212,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 			"aStr": &graphql.ArgumentConfig{Type: graphql.String},
 			"aInt": &graphql.ArgumentConfig{Type: graphql.Int},
 		},
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 			aStr, _ := p.Args["aStr"].(string)
 			aInt, _ := p.Args["aInt"].(int)
 			return &SubObjectWithJSONTags{
@@ -228,7 +228,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 			"int": 0,
 		},
 	}
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: `{ test { str, int } }`,
 	})
@@ -243,7 +243,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 			"int": 0,
 		},
 	}
-	result = graphql.Do(graphql.Params{
+	result = graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: `{ test(aStr: "String!") { str, int } }`,
 	})
@@ -257,7 +257,7 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 			"int": -123,
 		},
 	}
-	result = graphql.Do(graphql.Params{
+	result = graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: `{ test(aInt: -123, aStr: "String!") { str, int } }`,
 	})

--- a/executor_schema_test.go
+++ b/executor_schema_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -106,7 +107,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if author, ok := p.Source.(*testAuthor); ok {
 						width := fmt.Sprintf("%v", p.Args["width"])
 						height := fmt.Sprintf("%v", p.Args["height"])
@@ -156,14 +157,14 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 						Type: graphql.ID,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					id := p.Args["id"]
 					return article(id), nil
 				},
 			},
 			"feed": &graphql.Field{
 				Type: graphql.NewList(blogArticle),
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return []*testArticle{
 						article(1),
 						article(2),
@@ -305,7 +306,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 		Schema: blogSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}

--- a/executor_test.go
+++ b/executor_test.go
@@ -105,7 +105,7 @@ func TestExecutesArbitraryCode(t *testing.T) {
 	}
 
 	// Schema Definitions
-	picResolverFn := func(p graphql.ResolveParams) (interface{}, error) {
+	picResolverFn := func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 		// get and type assert ResolveFn for this field
 		picResolver, ok := p.Source.(map[string]interface{})["pic"].(func(size int) string)
 		if !ok {
@@ -200,7 +200,7 @@ func TestExecutesArbitraryCode(t *testing.T) {
 		OperationName: operationName,
 		Args:          args,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -243,13 +243,13 @@ func TestAliasedString(t *testing.T) {
 			Fields: graphql.Fields{
 				"foo": &graphql.Field{
 					Type: graphql.NewNonNull(graphql.String),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						return LikeAString("bar"), nil
 					},
 				},
 				"bar": &graphql.Field{
 					Type: graphql.NewNonNull(enumType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						return fooEnumValue, nil
 					},
 				},
@@ -267,7 +267,7 @@ func TestAliasedString(t *testing.T) {
 		Schema: schema,
 		AST:    astDoc,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -313,19 +313,19 @@ func TestMergesParallelFragments(t *testing.T) {
 		Fields: graphql.Fields{
 			"a": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return "Apple", nil
 				},
 			},
 			"b": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return "Banana", nil
 				},
 			},
 			"c": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return "Cherry", nil
 				},
 			},
@@ -333,7 +333,7 @@ func TestMergesParallelFragments(t *testing.T) {
 	})
 	deepTypeFieldConfig := &graphql.Field{
 		Type: typeObjectType,
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 			return p.Source, nil
 		},
 	}
@@ -354,7 +354,7 @@ func TestMergesParallelFragments(t *testing.T) {
 		Schema: schema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -380,7 +380,7 @@ func TestThreadsSourceCorrectly(t *testing.T) {
 			Fields: graphql.Fields{
 				"a": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						resolvedSource = p.Source.(map[string]interface{})
 						return resolvedSource, nil
 					},
@@ -401,7 +401,7 @@ func TestThreadsSourceCorrectly(t *testing.T) {
 		Root:   data,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -433,7 +433,7 @@ func TestOmitEmpty(t *testing.T) {
 			Fields: graphql.Fields{
 				"a": &graphql.Field{
 					Type: aType,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						return &struct {
 							B string `json:"b"`
 							C string `json:"c,omitempty"`
@@ -452,7 +452,7 @@ func TestOmitEmpty(t *testing.T) {
 		Schema: schema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -494,7 +494,7 @@ func TestCorrectlyThreadsArguments(t *testing.T) {
 						},
 					},
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						resolvedArgs = p.Args
 						return resolvedArgs, nil
 					},
@@ -514,7 +514,7 @@ func TestCorrectlyThreadsArguments(t *testing.T) {
 		Schema: schema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -541,7 +541,7 @@ func TestThreadsRootValueContextCorrectly(t *testing.T) {
 			Fields: graphql.Fields{
 				"a": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						val, _ := p.Info.RootValue.(map[string]interface{})["stringKey"].(string)
 						return val, nil
 					},
@@ -564,7 +564,7 @@ func TestThreadsRootValueContextCorrectly(t *testing.T) {
 			"stringKey": "stringValue",
 		},
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -591,8 +591,8 @@ func TestThreadsContextCorrectly(t *testing.T) {
 			Fields: graphql.Fields{
 				"a": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-						return p.Context.Value("foo"), nil
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
+						return ctx.Value("foo"), nil
 					},
 				},
 			},
@@ -607,11 +607,11 @@ func TestThreadsContextCorrectly(t *testing.T) {
 
 	// execute
 	ep := graphql.ExecuteParams{
-		Schema:  schema,
-		AST:     ast,
-		Context: context.WithValue(context.Background(), "foo", "bar"),
+		Schema: schema,
+		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	//nolint:staticcheck
+	result := testutil.TestExecute(t, context.WithValue(context.Background(), "foo", "bar"), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -684,7 +684,7 @@ func TestNullsOutErrorSubtrees(t *testing.T) {
 		AST:    ast,
 		Root:   data,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) == 0 {
 		t.Fatalf("wrong result, expected errors, got %v", len(result.Errors))
 	}
@@ -733,7 +733,7 @@ func TestUsesTheInlineOperationIfNoOperationNameIsProvided(t *testing.T) {
 		AST:    ast,
 		Root:   data,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -778,7 +778,7 @@ func TestUsesTheOnlyOperationIfNoOperationNameIsProvided(t *testing.T) {
 		AST:    ast,
 		Root:   data,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -822,7 +822,7 @@ func TestUsesTheNamedOperationIfOperationNameIsProvided(t *testing.T) {
 		Root:          data,
 		OperationName: "OtherExample",
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -868,7 +868,7 @@ func TestThrowsIfNoOperationIsProvided(t *testing.T) {
 		AST:    ast,
 		Root:   data,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != 1 {
 		t.Fatalf("wrong result, expected len(1) unexpected len: %v", len(result.Errors))
 	}
@@ -918,7 +918,7 @@ func TestThrowsIfNoOperationNameIsProvidedWithMultipleOperations(t *testing.T) {
 		AST:    ast,
 		Root:   data,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != 1 {
 		t.Fatalf("wrong result, expected len(1) unexpected len: %v", len(result.Errors))
 	}
@@ -969,7 +969,7 @@ func TestThrowsIfUnknownOperationNameIsProvided(t *testing.T) {
 		Root:          data,
 		OperationName: "UnknownExample",
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if result.Data != nil {
 		t.Fatalf("wrong result, expected nil result.Data, got %v", result.Data)
 	}
@@ -1031,7 +1031,7 @@ func TestUsesTheQuerySchemaForQueries(t *testing.T) {
 		Root:          data,
 		OperationName: "Q",
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1086,7 +1086,7 @@ func TestUsesTheMutationSchemaForMutations(t *testing.T) {
 		Root:          data,
 		OperationName: "M",
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1141,7 +1141,7 @@ func TestUsesTheSubscriptionSchemaForSubscriptions(t *testing.T) {
 		Root:          data,
 		OperationName: "S",
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1214,7 +1214,7 @@ func TestCorrectFieldOrderingDespiteExecutionOrder(t *testing.T) {
 		AST:    ast,
 		Root:   data,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1281,7 +1281,7 @@ func TestAvoidsRecursion(t *testing.T) {
 		Root:          data,
 		OperationName: "Q",
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1331,7 +1331,7 @@ func TestDoesNotIncludeIllegalFieldsInOutput(t *testing.T) {
 		Schema: schema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != 0 {
 		t.Fatalf("wrong result, expected len(%v) errors, got len(%v)", len(expected.Errors), len(result.Errors))
 	}
@@ -1373,7 +1373,7 @@ func TestDoesNotIncludeArgumentsThatWereNotSet(t *testing.T) {
 							Type: graphql.Int,
 						},
 					},
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						args, _ := json.Marshal(p.Args)
 						return string(args), nil
 					},
@@ -1393,7 +1393,7 @@ func TestDoesNotIncludeArgumentsThatWereNotSet(t *testing.T) {
 		Schema: schema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1448,7 +1448,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 		Fields: graphql.Fields{
 			"value": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return p.Source.(testSpecialType).Value, nil
 				},
 			},
@@ -1460,7 +1460,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 			Fields: graphql.Fields{
 				"specials": &graphql.Field{
 					Type: graphql.NewList(specialType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						return p.Source.(map[string]interface{})["specials"], nil
 					},
 				},
@@ -1480,7 +1480,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 		AST:    ast,
 		Root:   data,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) == 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1529,7 +1529,7 @@ func TestFailsToExecuteQueryContainingATypeDefinition(t *testing.T) {
 		Schema: schema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != 1 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1546,13 +1546,13 @@ func TestQuery_ExecutionAddsErrorsFromFieldResolveFn(t *testing.T) {
 		Fields: graphql.Fields{
 			"a": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return nil, qError
 				},
 			},
 			"b": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return "ok", nil
 				},
 			},
@@ -1565,7 +1565,7 @@ func TestQuery_ExecutionAddsErrorsFromFieldResolveFn(t *testing.T) {
 		t.Fatalf("unexpected error, got: %v", err)
 	}
 	query := "{ a }"
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        blogSchema,
 		RequestString: query,
 	})
@@ -1584,13 +1584,13 @@ func TestQuery_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 		Fields: graphql.Fields{
 			"a": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return nil, qError
 				},
 			},
 			"b": &graphql.Field{
 				Type: graphql.String,
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return "ok", nil
 				},
 			},
@@ -1603,7 +1603,7 @@ func TestQuery_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 		t.Fatalf("unexpected error, got: %v", err)
 	}
 	query := "{ b }"
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        blogSchema,
 		RequestString: query,
 	})
@@ -1632,7 +1632,7 @@ func TestMutation_ExecutionAddsErrorsFromFieldResolveFn(t *testing.T) {
 						Type: graphql.String,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return nil, mError
 				},
 			},
@@ -1643,7 +1643,7 @@ func TestMutation_ExecutionAddsErrorsFromFieldResolveFn(t *testing.T) {
 						Type: graphql.String,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return "ok", nil
 				},
 			},
@@ -1657,7 +1657,7 @@ func TestMutation_ExecutionAddsErrorsFromFieldResolveFn(t *testing.T) {
 		t.Fatalf("unexpected error, got: %v", err)
 	}
 	query := "mutation _ { newFoo: foo(f:\"title\") }"
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -1689,7 +1689,7 @@ func TestMutation_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 						Type: graphql.String,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return nil, mError
 				},
 			},
@@ -1700,7 +1700,7 @@ func TestMutation_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 						Type: graphql.String,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return "ok", nil
 				},
 			},
@@ -1714,7 +1714,7 @@ func TestMutation_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 		t.Fatalf("unexpected error, got: %v", err)
 	}
 	query := "mutation _ { newBar: bar(b:\"title\") }"
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -1749,7 +1749,7 @@ func TestMutation_NonNullSubField(t *testing.T) {
 		Fields: graphql.Fields{
 			"authenticate": &graphql.Field{
 				Type: graphql.NewNonNull(authenticatePayloadType),
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return struct {
 						Account *struct{} `json:"account"`
 					}{
@@ -1767,7 +1767,7 @@ func TestMutation_NonNullSubField(t *testing.T) {
 		t.Fatalf("unexpected error, got: %v", err)
 	}
 	query := "mutation _ { authenticate { account { id } } }"
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -1786,7 +1786,7 @@ func TestGraphqlTag(t *testing.T) {
 	var baz = &graphql.Field{
 		Type:        typeObjectType,
 		Description: "typeObjectType",
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 			t := struct {
 				FooBar string `graphql:"fooBar"`
 			}{"foo bar value"}
@@ -1806,7 +1806,7 @@ func TestGraphqlTag(t *testing.T) {
 		t.Fatalf("unexpected error, got: %v", err)
 	}
 	query := "{ baz { fooBar } }"
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -1841,7 +1841,7 @@ func TestContextDeadline(t *testing.T) {
 			Fields: graphql.Fields{
 				"hello": &graphql.Field{
 					Type: graphql.String,
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						time.Sleep(2 * time.Second)
 						return "world", nil
 					},
@@ -1859,10 +1859,9 @@ func TestContextDeadline(t *testing.T) {
 	defer cancel()
 
 	startTime := time.Now()
-	result := graphql.Do(graphql.Params{
+	result := graphql.Do(ctx, graphql.Params{
 		Schema:        schema,
 		RequestString: "{hello}",
-		Context:       ctx,
 	})
 	duration := time.Since(startTime)
 
@@ -1912,13 +1911,13 @@ func TestDeprecatedField(t *testing.T) {
 			Fields: graphql.Fields{
 				"foo": &graphql.Field{
 					Type: graphql.NewNonNull(graphql.String),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						return LikeAString("bar"), nil
 					},
 				},
 				"bar": &graphql.Field{
 					Type: graphql.NewNonNull(enumType),
-					Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 						return fooEnumValue, nil
 					},
 					DeprecationReason: "Use subtitleMarkup and bodyMarkup",
@@ -1944,7 +1943,7 @@ func TestDeprecatedField(t *testing.T) {
 			return nil
 		},
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1962,7 +1961,7 @@ func TestDeprecatedField(t *testing.T) {
 			return errors.New("deprecated field")
 		},
 	}
-	result = testutil.TestExecute(t, ep)
+	result = testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) == 0 {
 		t.Fatal("Expecte an error")
 	}

--- a/graphql.go
+++ b/graphql.go
@@ -28,13 +28,9 @@ type Params struct {
 	// possible operations. Can be omitted if requestString contains only
 	// one operation.
 	OperationName string
-
-	// Context may be provided to pass application-specific per-request
-	// information to resolve functions.
-	Context context.Context
 }
 
-func Do(p Params) *Result {
+func Do(ctx context.Context, p Params) *Result {
 	source := source.New("GraphQL request", p.RequestString)
 	ast, err := parser.Parse(parser.ParseParams{Source: source})
 	if err != nil {
@@ -50,13 +46,12 @@ func Do(p Params) *Result {
 		}
 	}
 
-	return Execute(ExecuteParams{
+	return Execute(ctx, ExecuteParams{
 		Schema:        p.Schema,
 		Root:          p.RootObject,
 		AST:           ast,
 		OperationName: p.OperationName,
 		Args:          p.VariableValues,
-		Context:       p.Context,
 	})
 }
 

--- a/introspection.go
+++ b/introspection.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -198,7 +199,7 @@ func init() {
 		Fields: Fields{
 			"kind": &Field{
 				Type: NewNonNull(TypeKindEnumType),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					switch p.Source.(type) {
 					case *Scalar:
 						return TypeKindScalar, nil
@@ -254,7 +255,7 @@ func init() {
 				Type: String,
 				Description: "A GraphQL-formatted string representing the default value for this " +
 					"input value.",
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					if inputVal, ok := p.Source.(*Argument); ok {
 						if inputVal.DefaultValue == nil {
 							return nil, nil
@@ -291,7 +292,7 @@ func init() {
 			},
 			"args": &Field{
 				Type: NewNonNull(NewList(NewNonNull(InputValueType))),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					if field, ok := p.Source.(*FieldDefinition); ok {
 						return field.Args, nil
 					}
@@ -303,7 +304,7 @@ func init() {
 			},
 			"isDeprecated": &Field{
 				Type: NewNonNull(Boolean),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					if field, ok := p.Source.(*FieldDefinition); ok {
 						return (field.DeprecationReason != ""), nil
 					}
@@ -346,7 +347,7 @@ func init() {
 			"onOperation": &Field{
 				DeprecationReason: "Use `locations`.",
 				Type:              NewNonNull(Boolean),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					if dir, ok := p.Source.(*Directive); ok {
 						res := false
 						for _, loc := range dir.Locations {
@@ -365,7 +366,7 @@ func init() {
 			"onFragment": &Field{
 				DeprecationReason: "Use `locations`.",
 				Type:              NewNonNull(Boolean),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					if dir, ok := p.Source.(*Directive); ok {
 						res := false
 						for _, loc := range dir.Locations {
@@ -384,7 +385,7 @@ func init() {
 			"onField": &Field{
 				DeprecationReason: "Use `locations`.",
 				Type:              NewNonNull(Boolean),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					if dir, ok := p.Source.(*Directive); ok {
 						res := false
 						for _, loc := range dir.Locations {
@@ -412,7 +413,7 @@ func init() {
 				Type: NewNonNull(NewList(
 					NewNonNull(TypeType),
 				)),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					if schema, ok := p.Source.(Schema); ok {
 						var results []Type
 						for _, ttype := range schema.TypeMap() {
@@ -429,7 +430,7 @@ func init() {
 			"queryType": &Field{
 				Description: "The type that query operations will be rooted at.",
 				Type:        NewNonNull(TypeType),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					if schema, ok := p.Source.(Schema); ok {
 						return schema.QueryType(), nil
 					}
@@ -440,7 +441,7 @@ func init() {
 				Description: `If this server supports mutation, the type that ` +
 					`mutation operations will be rooted at.`,
 				Type: TypeType,
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					if schema, ok := p.Source.(Schema); ok {
 						if schema.MutationType() != nil {
 							return schema.MutationType(), nil
@@ -453,7 +454,7 @@ func init() {
 				Description: `If this server supports subscription, the type that ` +
 					`subscription operations will be rooted at.`,
 				Type: TypeType,
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					if schema, ok := p.Source.(Schema); ok {
 						if schema.SubscriptionType() != nil {
 							return schema.SubscriptionType(), nil
@@ -467,7 +468,7 @@ func init() {
 				Type: NewNonNull(NewList(
 					NewNonNull(DirectiveType),
 				)),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					if schema, ok := p.Source.(Schema); ok {
 						return schema.Directives(), nil
 					}
@@ -491,7 +492,7 @@ func init() {
 			},
 			"isDeprecated": &Field{
 				Type: NewNonNull(Boolean),
-				Resolve: func(p ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 					if field, ok := p.Source.(*EnumValueDefinition); ok {
 						return (field.DeprecationReason != ""), nil
 					}
@@ -514,7 +515,7 @@ func init() {
 				DefaultValue: false,
 			},
 		},
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 			includeDeprecated, _ := p.Args["includeDeprecated"].(bool)
 			switch ttype := p.Source.(type) {
 			case *Object:
@@ -553,7 +554,7 @@ func init() {
 	})
 	TypeType.AddFieldConfig("interfaces", &Field{
 		Type: NewList(NewNonNull(TypeType)),
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 			switch ttype := p.Source.(type) {
 			case *Object:
 				return ttype.Interfaces(), nil
@@ -563,7 +564,7 @@ func init() {
 	})
 	TypeType.AddFieldConfig("possibleTypes", &Field{
 		Type: NewList(NewNonNull(TypeType)),
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 			switch ttype := p.Source.(type) {
 			case *Interface:
 				return p.Info.Schema.PossibleTypes(ttype), nil
@@ -581,7 +582,7 @@ func init() {
 				DefaultValue: false,
 			},
 		},
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 			includeDeprecated, _ := p.Args["includeDeprecated"].(bool)
 			switch ttype := p.Source.(type) {
 			case *Enum:
@@ -605,7 +606,7 @@ func init() {
 	})
 	TypeType.AddFieldConfig("inputFields", &Field{
 		Type: NewList(NewNonNull(InputValueType)),
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 			switch ttype := p.Source.(type) {
 			case *InputObject:
 				fields := []*InputObjectField{}
@@ -631,7 +632,7 @@ func init() {
 		Type:        NewNonNull(SchemaType),
 		Description: "Access the current type schema of this server.",
 		Args:        []*Argument{},
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 			return p.Info.Schema, nil
 		},
 	}
@@ -645,7 +646,7 @@ func init() {
 				Type:        NewNonNull(String),
 			},
 		},
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 			name, ok := p.Args["name"].(string)
 			if !ok {
 				return nil, nil
@@ -659,7 +660,7 @@ func init() {
 		Type:        NewNonNull(String),
 		Description: "The name of the current Object type at runtime.",
 		Args:        []*Argument{},
-		Resolve: func(p ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p ResolveParams) (interface{}, error) {
 			return p.Info.ParentType.Name(), nil
 		},
 	}

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -9,10 +10,6 @@ import (
 	"github.com/sprucehealth/graphql/language/location"
 	"github.com/sprucehealth/graphql/testutil"
 )
-
-func g(p graphql.Params) *graphql.Result {
-	return graphql.Do(p)
-}
 
 func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 	emptySchema, err := graphql.NewSchema(graphql.SchemaConfig{
@@ -778,7 +775,7 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 			},
 		},
 	}
-	result := g(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        emptySchema,
 		RequestString: testutil.IntrospectionQuery,
 	})
@@ -791,7 +788,6 @@ func TestIntrospection_ExecutesAnIntrospectionQuery(t *testing.T) {
 }
 
 func TestIntrospection_ExecutesAnInputObject(t *testing.T) {
-
 	testInputObject := graphql.NewInputObject(graphql.InputObjectConfig{
 		Name: "TestInputObject",
 		Fields: graphql.InputObjectConfigFieldMap{
@@ -814,7 +810,7 @@ func TestIntrospection_ExecutesAnInputObject(t *testing.T) {
 						Type: testInputObject,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return p.Args["complex"], nil
 				},
 			},
@@ -893,7 +889,7 @@ func TestIntrospection_ExecutesAnInputObject(t *testing.T) {
 		},
 	}
 
-	result := g(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -932,7 +928,7 @@ func TestIntrospection_SupportsThe__TypeRootField(t *testing.T) {
 			},
 		},
 	}
-	result := g(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -990,7 +986,7 @@ func TestIntrospection_IdentifiesDeprecatedFields(t *testing.T) {
 			},
 		},
 	}
-	result := g(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -1059,7 +1055,7 @@ func TestIntrospection_RespectsTheIncludeDeprecatedParameterForFields(t *testing
 			},
 		},
 	}
-	result := g(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -1132,7 +1128,7 @@ func TestIntrospection_IdentifiesDeprecatedEnumValues(t *testing.T) {
 			},
 		},
 	}
-	result := g(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -1221,7 +1217,7 @@ func TestIntrospection_RespectsTheIncludeDeprecatedParameterForEnumValues(t *tes
 			},
 		},
 	}
-	result := g(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -1264,7 +1260,7 @@ func TestIntrospection_FailsAsExpectedOnThe__TypeRootFieldWithoutAnArg(t *testin
 			},
 		},
 	}
-	result := g(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -1336,7 +1332,7 @@ func TestIntrospection_ExposesDescriptionsOnTypesAndFields(t *testing.T) {
 			},
 		},
 	}
-	result := g(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})
@@ -1414,7 +1410,7 @@ func TestIntrospection_ExposesDescriptionsOnEnums(t *testing.T) {
 			},
 		},
 	}
-	result := g(graphql.Params{
+	result := graphql.Do(context.Background(), graphql.Params{
 		Schema:        schema,
 		RequestString: query,
 	})

--- a/lists_test.go
+++ b/lists_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -25,7 +26,7 @@ func checkList(t *testing.T, testType graphql.Type, testData interface{}, expect
 	})
 	dataType.AddFieldConfig("nest", &graphql.Field{
 		Type: dataType,
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 			return data, nil
 		},
 	})
@@ -46,7 +47,7 @@ func checkList(t *testing.T, testType graphql.Type, testData interface{}, expect
 		AST:    ast,
 		Root:   data,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(expected.Errors) != len(result.Errors) {
 		t.Fatalf("wrong result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -66,7 +67,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
@@ -80,7 +81,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
@@ -94,7 +95,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
@@ -108,7 +109,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 						Type: graphql.Int,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
@@ -168,7 +169,7 @@ func TestMutations_ExecutionOrdering_EvaluatesMutationsSerially(t *testing.T) {
 		AST:    ast,
 		Root:   root,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -241,7 +242,7 @@ func TestMutations_EvaluatesMutationsCorrectlyInThePresenceOfAFailedMutation(t *
 		AST:    ast,
 		Root:   root,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}

--- a/nonnull_test.go
+++ b/nonnull_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
@@ -141,7 +142,7 @@ func TestNonNull_NullsANullableFieldThatThrowsSynchronously(t *testing.T) {
 		AST:    ast,
 		Root:   throwingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -181,7 +182,7 @@ func TestNonNull_NullsANullableFieldThatThrowsInAPromise(t *testing.T) {
 		AST:    ast,
 		Root:   throwingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -223,7 +224,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThat
 		AST:    ast,
 		Root:   throwingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -265,7 +266,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 		AST:    ast,
 		Root:   throwingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -307,7 +308,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 		AST:    ast,
 		Root:   throwingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -349,7 +350,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 		AST:    ast,
 		Root:   throwingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -511,7 +512,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 		AST:    ast,
 		Root:   throwingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -623,7 +624,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 		AST:    ast,
 		Root:   throwingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -660,7 +661,7 @@ func TestNonNull_NullsANullableFieldThatSynchronouslyReturnsNull(t *testing.T) {
 		AST:    ast,
 		Root:   nullingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -691,7 +692,7 @@ func TestNonNull_NullsANullableFieldThatSynchronouslyReturnsNullInAPromise(t *te
 		AST:    ast,
 		Root:   nullingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -733,7 +734,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 		AST:    ast,
 		Root:   nullingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -773,7 +774,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 		AST:    ast,
 		Root:   nullingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -814,7 +815,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 		AST:    ast,
 		Root:   nullingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -854,7 +855,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 		AST:    ast,
 		Root:   nullingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -929,7 +930,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatReturnNull(t *testing.T) {
 		AST:    ast,
 		Root:   nullingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1036,7 +1037,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
 		AST:    ast,
 		Root:   nullingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1078,7 +1079,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldThrows(t *testing.T) {
 		AST:    ast,
 		Root:   throwingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1112,7 +1113,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldErrors(t *testing.T) {
 		AST:    ast,
 		Root:   throwingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1146,7 +1147,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldReturnsNull(t *testing.T)
 		AST:    ast,
 		Root:   nullingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1180,7 +1181,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldResolvesNull(t *testing.T
 		AST:    ast,
 		Root:   nullingData,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}

--- a/rules_overlapping_fields_can_be_merged_test.go
+++ b/rules_overlapping_fields_can_be_merged_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sprucehealth/graphql"
@@ -311,7 +312,7 @@ var schema graphql.Schema
 func init() {
 	someBoxInterface = graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "SomeBox",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return stringBoxObject
 		},
 		Fields: graphql.FieldsThunk(func() graphql.Fields {
@@ -383,7 +384,7 @@ func init() {
 	})
 	var nonNullStringBox1Interface = graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "NonNullStringBox1",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return stringBoxObject
 		},
 		Fields: graphql.Fields{
@@ -411,7 +412,7 @@ func init() {
 	})
 	var nonNullStringBox2Interface = graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "NonNullStringBox2",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return stringBoxObject
 		},
 		Fields: graphql.Fields{

--- a/testutil/rules_test_harness.go
+++ b/testutil/rules_test_harness.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -255,7 +256,7 @@ func init() {
 			dogType,
 			humanType,
 		},
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			// not used for validation
 			return nil
 		},
@@ -266,7 +267,7 @@ func init() {
 			alienType,
 			humanType,
 		},
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			// not used for validation
 			return nil
 		},

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"strconv"
@@ -133,7 +134,7 @@ func init() {
 				Description: "Which movies they appear in.",
 			},
 		},
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			if character, ok := p.Value.(StarWarsChar); ok {
 				id, _ := strconv.Atoi(character.ID)
 				human := GetHuman(id)
@@ -156,7 +157,7 @@ func init() {
 			"id": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the human.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.ID, nil
 					}
@@ -166,7 +167,7 @@ func init() {
 			"name": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The name of the human.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.Name, nil
 					}
@@ -176,7 +177,7 @@ func init() {
 			"friends": &graphql.Field{
 				Type:        graphql.NewList(characterInterface),
 				Description: "The friends of the human, or an empty list if they have none.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.Friends, nil
 					}
@@ -186,7 +187,7 @@ func init() {
 			"appearsIn": &graphql.Field{
 				Type:        graphql.NewList(episodeEnum),
 				Description: "Which movies they appear in.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.AppearsIn, nil
 					}
@@ -196,7 +197,7 @@ func init() {
 			"homePlanet": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The home planet of the human, or null if unknown.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.HomePlanet, nil
 					}
@@ -215,7 +216,7 @@ func init() {
 			"id": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.String),
 				Description: "The id of the droid.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.ID, nil
 					}
@@ -225,7 +226,7 @@ func init() {
 			"name": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The name of the droid.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.Name, nil
 					}
@@ -235,7 +236,7 @@ func init() {
 			"friends": &graphql.Field{
 				Type:        graphql.NewList(characterInterface),
 				Description: "The friends of the droid, or an empty list if they have none.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						//friends := []map[string]interface{}{}
 						//for _, friend := range droid.Friends {
@@ -252,7 +253,7 @@ func init() {
 			"appearsIn": &graphql.Field{
 				Type:        graphql.NewList(episodeEnum),
 				Description: "Which movies they appear in.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.AppearsIn, nil
 					}
@@ -262,7 +263,7 @@ func init() {
 			"primaryFunction": &graphql.Field{
 				Type:        graphql.String,
 				Description: "The primary function of the droid.",
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.PrimaryFunction, nil
 					}
@@ -287,7 +288,7 @@ func init() {
 						Type: episodeEnum,
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return GetHero(p.Args["episode"]), nil
 				},
 			},
@@ -299,7 +300,7 @@ func init() {
 						Type:        graphql.NewNonNull(graphql.String),
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return GetHuman(p.Args["id"].(int)), nil
 				},
 			},
@@ -311,7 +312,7 @@ func init() {
 						Type:        graphql.NewNonNull(graphql.String),
 					},
 				},
-				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 					return GetDroid(p.Args["id"].(int)), nil
 				},
 			},
@@ -356,8 +357,9 @@ func TestParse(t testing.TB, query string) *ast.Document {
 	}
 	return astDoc
 }
-func TestExecute(t testing.TB, ep graphql.ExecuteParams) *graphql.Result {
-	return graphql.Execute(ep)
+
+func TestExecute(t testing.TB, ctx context.Context, ep graphql.ExecuteParams) *graphql.Result {
+	return graphql.Execute(ctx, ep)
 }
 
 func Diff(a, b interface{}) []string {

--- a/union_interface_test.go
+++ b/union_interface_test.go
@@ -78,7 +78,7 @@ var petType = graphql.NewUnion(graphql.UnionConfig{
 	Types: []*graphql.Object{
 		dogType, catType,
 	},
-	ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+	ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 		if _, ok := p.Value.(*testCat2); ok {
 			return catType
 		}
@@ -204,7 +204,7 @@ func TestUnionIntersectionTypes_CanIntrospectOnUnionAndIntersectionTypes(t *test
 		Schema: unionInterfaceTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -253,7 +253,7 @@ func TestUnionIntersectionTypes_ExecutesUsingUnionTypes(t *testing.T) {
 		AST:    ast,
 		Root:   john,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -307,7 +307,7 @@ func TestUnionIntersectionTypes_ExecutesUnionTypesWithInlineFragments(t *testing
 		AST:    ast,
 		Root:   john,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -356,7 +356,7 @@ func TestUnionIntersectionTypes_ExecutesUsingInterfaceTypes(t *testing.T) {
 		AST:    ast,
 		Root:   john,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -409,7 +409,7 @@ func TestUnionIntersectionTypes_ExecutesInterfaceTypesWithInlineFragments(t *tes
 		AST:    ast,
 		Root:   john,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -489,7 +489,7 @@ func TestUnionIntersectionTypes_AllowsFragmentConditionsToBeAbstractTypes(t *tes
 		AST:    ast,
 		Root:   john,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -511,9 +511,9 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 				Type: graphql.String,
 			},
 		},
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			encounteredSchema = p.Info.Schema
-			encounteredContextValue, _ = p.Context.Value("authToken").(string)
+			encounteredContextValue, _ = ctx.Value("authToken").(string)
 			encounteredRootValue = p.Info.RootValue.(*testPerson).Name
 			return personType2
 		},
@@ -561,16 +561,16 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 
 	// create context
 	ctx := context.Background()
+	//nolint:staticcheck
 	ctx = context.WithValue(ctx, "authToken", "contextStringValue123")
 
 	// execute
 	ep := graphql.ExecuteParams{
-		Schema:  schema2,
-		AST:     ast,
-		Root:    john2,
-		Context: ctx,
+		Schema: schema2,
+		AST:    ast,
+		Root:   john2,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, ctx, ep)
 
 	if !reflect.DeepEqual(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sprucehealth/graphql"
@@ -40,7 +41,7 @@ var objectWithIsTypeOf = graphql.NewObject(graphql.ObjectConfig{
 })
 var someUnionType = graphql.NewUnion(graphql.UnionConfig{
 	Name: "SomeUnion",
-	ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+	ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 		return nil
 	},
 	Types: []*graphql.Object{
@@ -49,7 +50,7 @@ var someUnionType = graphql.NewUnion(graphql.UnionConfig{
 })
 var someInterfaceType = graphql.NewInterface(graphql.InterfaceConfig{
 	Name: "SomeInterface",
-	ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+	ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 		return nil
 	},
 	Fields: graphql.Fields{
@@ -181,7 +182,7 @@ func schemaWithUnionOfType(ttype *graphql.Object) (graphql.Schema, error) {
 
 	badObjectType := graphql.NewUnion(graphql.UnionConfig{
 		Name: "BadUnion",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Types: []*graphql.Object{ttype},
@@ -386,7 +387,7 @@ func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichDefin
 func TestTypeSystem_SchemaMustContainUniquelyNamedTypes_RejectsASchemaWhichHaveSameNamedObjectsImplementingAnInterface(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -545,7 +546,7 @@ func TestTypeSystem_FieldsArgsMustBeObjects_AcceptsAnObjectTypeWithFieldArgs(t *
 func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithArrayInterfaces(t *testing.T) {
 	anotherInterfaceType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -573,7 +574,7 @@ func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithArrayInte
 func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithInterfacesAsFunctionReturningAnArray(t *testing.T) {
 	anotherInterfaceType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -599,7 +600,7 @@ func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithInterface
 func TestTypeSystem_UnionTypesMustBeArray_AcceptsAUnionTypeWithArrayTypes(t *testing.T) {
 	_, err := schemaWithFieldType(graphql.NewUnion(graphql.UnionConfig{
 		Name: "SomeUnion",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Types: []*graphql.Object{
@@ -613,7 +614,7 @@ func TestTypeSystem_UnionTypesMustBeArray_AcceptsAUnionTypeWithArrayTypes(t *tes
 func TestTypeSystem_UnionTypesMustBeArray_RejectsAUnionTypeWithoutTypes(t *testing.T) {
 	_, err := schemaWithFieldType(graphql.NewUnion(graphql.UnionConfig{
 		Name: "SomeUnion",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 	}))
@@ -625,7 +626,7 @@ func TestTypeSystem_UnionTypesMustBeArray_RejectsAUnionTypeWithoutTypes(t *testi
 func TestTypeSystem_UnionTypesMustBeArray_RejectsAUnionTypeWithEmptyTypes(t *testing.T) {
 	_, err := schemaWithFieldType(graphql.NewUnion(graphql.UnionConfig{
 		Name: "SomeUnion",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Types: []*graphql.Object{},
@@ -707,7 +708,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceTypeDefinin
 
 	anotherInterfaceType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -759,7 +760,7 @@ func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceWithImpleme
 func TestTypeSystem_InterfaceTypesMustBeResolvable_AcceptsAnInterfaceTypeDefiningResolveTypeWithImplementingTypeDefiningIsTypeOf(t *testing.T) {
 	anotherInterfaceType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -790,7 +791,7 @@ func TestTypeSystem_UnionTypesMustBeResolvable_AcceptsAUnionTypeDefiningResolveT
 	_, err := schemaWithFieldType(graphql.NewUnion(graphql.UnionConfig{
 		Name:  "SomeUnion",
 		Types: []*graphql.Object{someObjectType},
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 	}))
@@ -813,7 +814,7 @@ func TestTypeSystem_UnionTypesMustBeResolvable_AcceptsAUnionTypeDefiningResolveT
 	_, err := schemaWithFieldType(graphql.NewUnion(graphql.UnionConfig{
 		Name:  "SomeUnion",
 		Types: []*graphql.Object{objectWithIsTypeOf},
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 	}))
@@ -981,7 +982,7 @@ func TestTypeSystem_ObjectFieldsMustHaveOutputTypes_RejectsAnEmptyObjectFieldTyp
 func TestTypeSystem_ObjectsCanOnlyImplementInterfaces_AcceptsAnObjectImplementingAnInterface(t *testing.T) {
 	anotherInterfaceType := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1119,7 +1120,7 @@ func TestTypeSystem_NonNullMustAcceptGraphQLTypes_RejectsNilAsNonNullableType(t 
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhichImplementsAnInterface(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1155,7 +1156,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhichImplementsAnInterfaceAlongWithMoreFields(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1195,7 +1196,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhichImpementsAnInterfaceFieldAlongWithAdditionalOptionalArguments(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1235,7 +1236,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWhichImplementsAnInterfaceFieldAlongWithAdditionalRequiredArguments(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1276,7 +1277,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWhi
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMissingAnInterfaceField(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1309,7 +1310,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMis
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWithAnIncorrectlyTypedInterfaceField(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1336,7 +1337,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMissingAnInterfaceArgument(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(info graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, info graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1368,7 +1369,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMis
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWithAnIncorrectlyTypedInterfaceArgument(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(info graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, info graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1423,7 +1424,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1452,7 +1453,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWit
 	var anotherInterface *graphql.Interface
 	anotherInterface = graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: (graphql.FieldsThunk)(func() graphql.Fields {
@@ -1484,7 +1485,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWit
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWithASubtypedInterfaceField_Union(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1511,7 +1512,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWit
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWithANonListInterfaceFieldListType(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1539,7 +1540,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWithAListInterfaceFieldNonListType(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1567,7 +1568,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWithAnEquivalentlyModifiedInterfaceField(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1594,7 +1595,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWit
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWithSubsetNonNullInterfaceFieldType(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{
@@ -1621,7 +1622,7 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWit
 func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWithASupersetNullableInterfaceFieldType(t *testing.T) {
 	anotherInterface := graphql.NewInterface(graphql.InterfaceConfig{
 		Name: "AnotherInterface",
-		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
+		ResolveType: func(ctx context.Context, p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
 		Fields: graphql.Fields{

--- a/variables_test.go
+++ b/variables_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -65,7 +66,7 @@ var testNestedInputObject *graphql.InputObject = graphql.NewInputObject(graphql.
 	},
 })
 
-func inputResolved(p graphql.ResolveParams) (interface{}, error) {
+func inputResolved(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
 	input, ok := p.Args["input"]
 	if !ok {
 		return nil, nil
@@ -189,7 +190,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_ExecutesWithComplexI
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -216,7 +217,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_ProperlyParsesSingle
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -243,7 +244,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_DoesNotUseIncorrectV
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -270,7 +271,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_ProperlyRunsParseLit
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -310,7 +311,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ExecutesWithComplexInput
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -339,7 +340,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_UsesDefaultValueWhenNotP
 		Schema: variablesTestSchema,
 		AST:    withDefaultsAST,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -369,7 +370,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ProperlyParsesSingleValu
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -398,7 +399,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ExecutesWithComplexScala
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -438,7 +439,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnNullForNestedNon
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -473,7 +474,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnIncorrectType(t 
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -512,7 +513,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnOmissionOfNested
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -558,7 +559,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnDeepNestedErrors
 		AST:    nestedAST,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -599,7 +600,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnAdditionOfUnknow
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -627,7 +628,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeOmitted(t *testing.T)
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -654,7 +655,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeOmittedInAVariable(t 
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -681,7 +682,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeOmittedInAnUnlistedVa
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -712,7 +713,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeSetToNullInAVariable(
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -743,7 +744,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeSetToAValueInAVariabl
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -770,7 +771,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeSetToAValueDirectly(t
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -809,7 +810,7 @@ func TestVariables_NonNullableScalars_DoesNotAllowNonNullableInputsToBeOmittedIn
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -850,7 +851,7 @@ func TestVariables_NonNullableScalars_DoesNotAllowNonNullableInputsToBeSetToNull
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -882,7 +883,7 @@ func TestVariables_NonNullableScalars_AllowsNonNullableInputsToBeSetToAValueInAV
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -915,7 +916,7 @@ func TestVariables_NonNullableScalars_AllowsNonNullableInputsToBeSetToAValueDire
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -948,7 +949,7 @@ func TestVariables_NonNullableScalars_PassesAlongNullForNonNullableInputsIfExpli
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -980,7 +981,7 @@ func TestVariables_ListsAndNullability_AllowsListsToBeNull(t *testing.T) {
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1011,7 +1012,7 @@ func TestVariables_ListsAndNullability_AllowsListsToContainValues(t *testing.T) 
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1042,7 +1043,7 @@ func TestVariables_ListsAndNullability_AllowsListsToContainNull(t *testing.T) {
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1077,7 +1078,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowNonNullListsToBeNull(t *testi
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1107,7 +1108,7 @@ func TestVariables_ListsAndNullability_AllowsNonNullListsToContainValues(t *test
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1137,7 +1138,7 @@ func TestVariables_ListsAndNullability_AllowsNonNullListsToContainNull(t *testin
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1167,7 +1168,7 @@ func TestVariables_ListsAndNullability_AllowsListsOfNonNullsToBeNull(t *testing.
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1197,7 +1198,7 @@ func TestVariables_ListsAndNullability_AllowsListsOfNonNullsToContainValues(t *t
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
@@ -1238,7 +1239,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowListOfNonNullsToContainNull(t
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1277,7 +1278,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowNonNullListOfNonNullsToBeNull
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1307,7 +1308,7 @@ func TestVariables_ListsAndNullability_AllowsNonNullListsOfNonNulsToContainValue
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1348,7 +1349,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowNonNullListOfNonNullsToContai
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1389,7 +1390,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowInvalidTypesToBeUsedAsValues(
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1428,7 +1429,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowUnknownTypesToBeUsedAsValues(
 		AST:    ast,
 		Args:   params,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1455,7 +1456,7 @@ func TestVariables_UsesArgumentDefaultValues_WhenNoArgumentProvided(t *testing.T
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1481,7 +1482,7 @@ func TestVariables_UsesArgumentDefaultValues_WhenNullableVariableProvided(t *tes
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
@@ -1507,7 +1508,7 @@ func TestVariables_UsesArgumentDefaultValues_WhenArgumentProvidedCannotBeParsed(
 		Schema: variablesTestSchema,
 		AST:    ast,
 	}
-	result := testutil.TestExecute(t, ep)
+	result := testutil.TestExecute(t, context.Background(), ep)
 	if len(result.Errors) != len(expected.Errors) {
 		t.Fatalf("Unexpected errors, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}


### PR DESCRIPTION
This is more idiomatic but the main reason for making this change is I want to try to propagate context changes down the execution graph. That change isn't in this PR however and will come after.