### PR TITLE
add support for field definition directives, handlers, and identity

### DIFF
--- a/cmd/graphql2go/main.go
+++ b/cmd/graphql2go/main.go
@@ -142,7 +142,15 @@ func main() {
 	}
 
 	g := newGenerator(outWriter, root)
-	g.assertAllowIdentityAssumptionConditions(root)
+	for _, def := range g.doc.Definitions {
+		switch def := def.(type) {
+		case *ast.DirectiveDefinition:
+			// If the assert allow identity assumption directive is defined, assert it's usage
+			if def.Name.Value == "allowAssumedIdentity" {
+				g.assertAllowIdentityAssumptionConditions(root)
+			}
+		}
+	}
 
 	switch *flagArtifact {
 	case "server":

--- a/cmd/graphql2go/main.go
+++ b/cmd/graphql2go/main.go
@@ -394,11 +394,11 @@ func (g *generator) assertAllowIdentityAssumptionConditionsOnFields(parentName s
 	for _, f := range fieldDefs {
 		allow, ok := identityAssumptionDirectiveAllowValue(f.Directives)
 		if !ok && requiredOnAll {
-			log.Fatalf("@allowAssumedIdentity directive required on field %q since parent %q is top level or has @allowAssumedIdentity(allow: true)", f.Name.Value, parentName)
+			g.failf("@allowAssumedIdentity directive required on field %q since parent %q is top level or has @allowAssumedIdentity(allow: true)", f.Name.Value, parentName)
 		}
 		def := g.defForType(f.Type)
 		if def == nil {
-			log.Fatalf("unable to resolve def for type %q", f.Type)
+			g.failf("unable to resolve def for type %q", f.Type)
 		}
 		switch d := def.(type) {
 		case *ast.ObjectDefinition:

--- a/cmd/graphql2go/main.go
+++ b/cmd/graphql2go/main.go
@@ -142,6 +142,7 @@ func main() {
 	}
 
 	g := newGenerator(outWriter, root)
+	g.assertAllowIdentityAssumptionConditions(root)
 
 	switch *flagArtifact {
 	case "server":
@@ -226,6 +227,14 @@ func generateServer(g *generator) {
 		}
 		g.printf("}\n\n")
 	}
+	g.printf("var Directives = []*graphql.Directive{\n")
+	for _, def := range g.doc.Definitions {
+		switch def := def.(type) {
+		case *ast.DirectiveDefinition:
+			g.printf("\t%s,\n", goDirectiveDefName(def.Name.Value))
+		}
+	}
+	g.printf("}\n\n")
 	// Generate types
 	for _, def := range g.doc.Definitions {
 		g.genNode(def)
@@ -247,6 +256,8 @@ func generateServer(g *generator) {
 			name = goEnumDefName(def.Name.Value)
 		case *ast.ScalarDefinition:
 			name = goScalarDefName(def.Name.Value)
+		case *ast.DirectiveDefinition:
+			continue
 		default:
 			log.Fatalf("Unhandled node type %T", def)
 		}
@@ -292,6 +303,8 @@ func newGenerator(outWriter io.Writer, root *ast.Document) *generator {
 		case *ast.UnionDefinition:
 			name = def.Name.Value
 		case *ast.ScalarDefinition:
+			name = def.Name.Value
+		case *ast.DirectiveDefinition:
 			name = def.Name.Value
 		default:
 			log.Fatalf("Unhandled node type %T", def)
@@ -358,6 +371,53 @@ func newGenerator(outWriter io.Writer, root *ast.Document) *generator {
 	return g
 }
 
+func (g *generator) assertAllowIdentityAssumptionConditions(root *ast.Document) {
+	for _, def := range root.Definitions {
+		switch d := def.(type) {
+		case *ast.ObjectDefinition:
+			if isTopLevelObject(d.Name.Value) {
+				g.assertAllowIdentityAssumptionConditionsOnFields(d.Name.Value, d.Fields, make(map[string]struct{}), true)
+			}
+		}
+	}
+}
+
+func (g *generator) assertAllowIdentityAssumptionConditionsOnFields(parentName string, fieldDefs []*ast.FieldDefinition, seenTypes map[string]struct{}, requiredOnAll bool) {
+	for _, f := range fieldDefs {
+		allow, ok := identityAssumptionDirectiveAllowValue(f.Directives)
+		if !ok && requiredOnAll {
+			log.Fatalf("@allowAssumedIdentity directive required on field %q since parent %q is top level or has @allowAssumedIdentity(allow: true)", f.Name.Value, parentName)
+		}
+		def := g.defForType(f.Type)
+		if def == nil {
+			log.Fatalf("unable to resolve def for type %q", f.Type)
+		}
+		switch d := def.(type) {
+		case *ast.ObjectDefinition:
+			// avoid cycles
+			if _, ok := seenTypes[d.Name.Value]; !ok {
+				seenTypes[d.Name.Value] = struct{}{}
+				g.assertAllowIdentityAssumptionConditionsOnFields(f.Name.Value+":"+f.Type.String(), d.Fields, seenTypes, allow)
+			}
+		}
+	}
+}
+
+// identityAssumptionDirectiveAllowValue returns the value directive and a boolean representing if the directive was found at all
+func identityAssumptionDirectiveAllowValue(ds []*ast.Directive) (bool, bool) {
+	for _, d := range ds {
+		if d.Name.Value == "allowAssumedIdentity" {
+			for _, a := range d.Arguments {
+				if a.Name.Value == "allow" {
+					allow, ok := a.Value.GetValue().(bool)
+					return allow, ok
+				}
+			}
+		}
+	}
+	return false, false
+}
+
 func cycleKey(path []string) string {
 	// Avoid modifying the path so clone it
 	p := append([]string(nil), path...)
@@ -416,6 +476,8 @@ func (g *generator) findCycles(def ast.Node, ancestors []string) {
 		// Enums can't form cycles
 		return
 	case *ast.ScalarDefinition:
+		// Don't think cycles are possible
+	case *ast.DirectiveDefinition:
 		// Don't think cycles are possible
 	default:
 		log.Fatalf("Unhandled node type %T", def)
@@ -521,6 +583,9 @@ func (g *generator) genNode(node ast.Node) {
 	case *ast.ScalarDefinition:
 		g.genScalarDefinition(def)
 		g.printf("\n")
+	case *ast.DirectiveDefinition:
+		g.genDirectiveDefinition(def)
+		g.printf("\n")
 	default:
 		log.Fatalf("Unhandled node type %T", node)
 	}
@@ -606,6 +671,24 @@ func (g *generator) genUnionModel(def *ast.UnionDefinition) {
 	// TODO: do we want anything here to make guarantees of match?
 	g.printf("type %s interface {\n", exportedName(def.Name.Value))
 	g.printf("}\n")
+}
+
+func (g *generator) genDirectiveDefinition(def *ast.DirectiveDefinition) {
+	g.printf("var %s = graphql.NewDirective(graphql.DirectiveConfig{\n", goDirectiveDefName(def.Name.Value))
+	g.printf("\tName: %q,\n", def.Name.Value)
+	g.printf("\tLocations: []string{\n")
+	for _, l := range def.Locations {
+		g.printf("\t\t%q,\n", l.Value)
+	}
+	g.printf("\t},\n")
+	if len(def.Arguments) != 0 {
+		g.printf("\tArgs: graphql.FieldConfigArgument{")
+		for _, a := range def.Arguments {
+			g.printf(g.renderArgumentConfig(a, "\t\t") + ",")
+		}
+		g.printf("\t},\n")
+	}
+	g.printf("})\n")
 }
 
 func (g *generator) genScalarDefinition(def *ast.ScalarDefinition) {
@@ -719,6 +802,7 @@ func (g *generator) genObjectDefinition(def *ast.ObjectDefinition) {
 			g.printf("%s,\n", g.renderFieldDefinition(def.Name.Value, f, "\t\t", false))
 		}
 	}
+	g.print("\t")
 	g.printf("\t},\n")
 	g.printf("\tIsTypeOf: func(p graphql.IsTypeOfParams) bool {\n")
 	g.printf("\t\t_, ok := p.Value.(*%s)\n", exportedName(def.Name.Value))
@@ -822,8 +906,6 @@ func (g *generator) deprecationReasonFromDirectives(dirs []*ast.Directive, paren
 					g.failf("Unsupport argument %q directive %q on %s", derefName(a.Name, ""), derefName(d.Name, ""), parent)
 				}
 			}
-		} else {
-			g.failf("Unsupport directive %q on %s", derefName(d.Name, ""), parent)
 		}
 	}
 	return deprecationReason
@@ -867,6 +949,21 @@ func (g *generator) renderFieldDefinition(objName string, def *ast.FieldDefiniti
 	}
 	if deprecationReason != "" {
 		lines = append(lines, fmt.Sprintf("%s\tDeprecationReason: %s,", indent, renderDeprecationReason(deprecationReason)))
+	}
+	nonDeprecatedDirectives := make([]*ast.Directive, 0, len(def.Directives))
+	for _, d := range def.Directives {
+		if d.Name.Value != "deprecated" {
+			nonDeprecatedDirectives = append(nonDeprecatedDirectives, d)
+		}
+	}
+	if len(nonDeprecatedDirectives) != 0 {
+		lines = append(lines, indent+"\tDirectives: []*ast.Directive{")
+		for _, d := range def.Directives {
+			if d.Name.Value != "deprecated" {
+				lines = append(lines, g.renderASTDirective(d, indent+"\t\t", true)+",")
+			}
+		}
+		lines = append(lines, indent+"\t},")
 	}
 	if customResolve {
 		goFieldName := exportedName(def.Name.Value)
@@ -991,6 +1088,35 @@ func (g *generator) renderInputValueDefinition(objDef *ast.InputObjectDefinition
 	if def.DefaultValue != nil {
 		lines = append(lines, fmt.Sprintf("%s\tDefaultValue: %s,", indent, g.renderValue(objDef.Name.Value+"."+def.Name.Value, def.Type, def.DefaultValue)))
 	}
+	lines = append(lines, indent+"}")
+	return strings.Join(lines, "\n")
+}
+
+func (g *generator) renderASTDirective(def *ast.Directive, indent string, inSliceLiteral bool) string {
+	lines := []string{indent + "&ast.Directive{"}
+	if inSliceLiteral {
+		lines[0] = "{"
+	}
+	lines = append(lines, fmt.Sprintf(indent+"\tName: &ast.Name{Value: %q},", def.Name.Value))
+	if len(def.Arguments) != 0 {
+		lines = append(lines, indent+"\tArguments: []*ast.Argument{")
+		for _, a := range def.Arguments {
+			lines = append(lines, g.renderASTArgument(a, indent+"\t\t", true)+",")
+		}
+		lines = append(lines, indent+"\t},")
+	}
+	lines = append(lines, indent+"}")
+	return strings.Join(lines, "\n")
+}
+
+func (g *generator) renderASTArgument(def *ast.Argument, indent string, inSliceLiteral bool) string {
+	lines := []string{indent + "&ast.Argument{"}
+	if inSliceLiteral {
+		lines[0] = "{"
+	}
+	lines = append(lines, fmt.Sprintf(indent+"\tName: &ast.Name{Value: %q},", def.Name.Value))
+	// HACK/TODO: For now only support rendering boolean AST arguments. This is to save time figuring out how to support more
+	lines = append(lines, fmt.Sprintf(indent+"\tValue: &ast.BooleanValue{Value: %t},", def.Value.GetValue()))
 	lines = append(lines, indent+"}")
 	return strings.Join(lines, "\n")
 }
@@ -1241,6 +1367,10 @@ func interfaceMarker(typeName string) string {
 }
 
 func goObjectDefName(name string) string {
+	return exportedName(name) + "Def"
+}
+
+func goDirectiveDefName(name string) string {
 	return exportedName(name) + "Def"
 }
 

--- a/definition.go
+++ b/definition.go
@@ -221,13 +221,12 @@ func GetNamed(ttype Type) Named {
 //
 // Example:
 //
-//    var OddType = new Scalar({
-//      name: 'Odd',
-//      serialize(value) {
-//        return value % 2 === 1 ? value : null;
-//      }
-//    });
-//
+//	var OddType = new Scalar({
+//	  name: 'Odd',
+//	  serialize(value) {
+//	    return value % 2 === 1 ? value : null;
+//	  }
+//	});
 type Scalar struct {
 	PrivateName        string `json:"name"`
 	PrivateDescription string `json:"description"`
@@ -324,19 +323,19 @@ func (st *Scalar) Error() error {
 // have a name, but most importantly describe their fields.
 // Example:
 //
-//    var AddressType = new Object({
-//      name: 'Address',
-//      fields: {
-//        street: { type: String },
-//        number: { type: Int },
-//        formatted: {
-//          type: String,
-//          resolve(obj) {
-//            return obj.number + ' ' + obj.street
-//          }
-//        }
-//      }
-//    });
+//	var AddressType = new Object({
+//	  name: 'Address',
+//	  fields: {
+//	    street: { type: String },
+//	    number: { type: Int },
+//	    formatted: {
+//	      type: String,
+//	      resolve(obj) {
+//	        return obj.number + ' ' + obj.street
+//	      }
+//	    }
+//	  }
+//	});
 //
 // When two types need to refer to each other, or a type needs to refer to
 // itself in a field, you can use a function expression (aka a closure or a
@@ -344,13 +343,13 @@ func (st *Scalar) Error() error {
 //
 // Example:
 //
-//    var PersonType = new Object({
-//      name: 'Person',
-//      fields: () => ({
-//        name: { type: String },
-//        bestFriend: { type: PersonType },
-//      })
-//    });
+//	var PersonType = new Object({
+//	  name: 'Person',
+//	  fields: () => ({
+//	    name: { type: String },
+//	    bestFriend: { type: PersonType },
+//	  })
+//	});
 //
 // /
 type Object struct {
@@ -547,6 +546,7 @@ func defineFieldMap(ttype Named, fields Fields) (FieldDefinitionMap, error) {
 			Type:              field.Type,
 			Resolve:           field.Resolve,
 			DeprecationReason: field.DeprecationReason,
+			Directives:        field.Directives,
 		}
 
 		if len(field.Args) != 0 {
@@ -609,8 +609,9 @@ type Field struct {
 	Type              Output              `json:"type"`
 	Args              FieldConfigArgument `json:"args"`
 	Resolve           FieldResolveFn
-	DeprecationReason string `json:"deprecationReason,omitempty"`
-	Description       string `json:"description"`
+	DeprecationReason string           `json:"deprecationReason,omitempty"`
+	Description       string           `json:"description"`
+	Directives        []*ast.Directive `json:"directives,omitempty"`
 }
 
 type FieldConfigArgument map[string]*ArgumentConfig
@@ -623,12 +624,13 @@ type ArgumentConfig struct {
 
 type FieldDefinitionMap map[string]*FieldDefinition
 type FieldDefinition struct {
-	Name              string         `json:"name"`
-	Description       string         `json:"description"`
-	Type              Output         `json:"type"`
-	Args              []*Argument    `json:"args"`
-	Resolve           FieldResolveFn `json:"-"`
-	DeprecationReason string         `json:"deprecationReason,omitempty"`
+	Name              string           `json:"name"`
+	Description       string           `json:"description"`
+	Type              Output           `json:"type"`
+	Args              []*Argument      `json:"args"`
+	Resolve           FieldResolveFn   `json:"-"`
+	DeprecationReason string           `json:"deprecationReason,omitempty"`
+	Directives        []*ast.Directive `json:"directives,omitempty"`
 }
 
 type FieldArgument struct {
@@ -668,14 +670,12 @@ func (st *Argument) Error() error {
 //
 // Example:
 //
-//     var EntityType = new Interface({
-//       name: 'Entity',
-//       fields: {
-//         name: { type: String }
-//       }
-//     });
-//
-//
+//	var EntityType = new Interface({
+//	  name: 'Entity',
+//	  fields: {
+//	    name: { type: String }
+//	  }
+//	});
 type Interface struct {
 	PrivateName        string `json:"name"`
 	PrivateDescription string `json:"description"`
@@ -790,18 +790,18 @@ func (it *Interface) Error() error {
 //
 // Example:
 //
-//     var PetType = new Union({
-//       name: 'Pet',
-//       types: [ DogType, CatType ],
-//       resolveType(value) {
-//         if (value instanceof Dog) {
-//           return DogType;
-//         }
-//         if (value instanceof Cat) {
-//           return CatType;
-//         }
-//       }
-//     });
+//	var PetType = new Union({
+//	  name: 'Pet',
+//	  types: [ DogType, CatType ],
+//	  resolveType(value) {
+//	    if (value instanceof Dog) {
+//	      return DogType;
+//	    }
+//	    if (value instanceof Cat) {
+//	      return CatType;
+//	    }
+//	  }
+//	});
 type Union struct {
 	PrivateName        string `json:"name"`
 	PrivateDescription string `json:"description"`
@@ -1059,18 +1059,18 @@ func (gt *Enum) getNameLookup() map[string]*EnumValueDefinition {
 // An input object defines a structured collection of fields which may be
 // supplied to a field argument.
 //
-// Using `NonNull` will ensure that a value must be provided by the query
+// # Using `NonNull` will ensure that a value must be provided by the query
 //
 // Example:
 //
-//     var GeoPoint = new InputObject({
-//       name: 'GeoPoint',
-//       fields: {
-//         lat: { type: new NonNull(Float) },
-//         lon: { type: new NonNull(Float) },
-//         alt: { type: Float, defaultValue: 0 },
-//       }
-//     });
+//	var GeoPoint = new InputObject({
+//	  name: 'GeoPoint',
+//	  fields: {
+//	    lat: { type: new NonNull(Float) },
+//	    lon: { type: new NonNull(Float) },
+//	    alt: { type: Float, defaultValue: 0 },
+//	  }
+//	});
 type InputObject struct {
 	PrivateName        string `json:"name"`
 	PrivateDescription string `json:"description"`
@@ -1216,14 +1216,13 @@ func (gt *InputObject) Error() error {
 //
 // Example:
 //
-//     var PersonType = new Object({
-//       name: 'Person',
-//       fields: () => ({
-//         parents: { type: new List(Person) },
-//         children: { type: new List(Person) },
-//       })
-//     })
-//
+//	var PersonType = new Object({
+//	  name: 'Person',
+//	  fields: () => ({
+//	    parents: { type: new List(Person) },
+//	    children: { type: new List(Person) },
+//	  })
+//	})
 type List struct {
 	OfType Type `json:"ofType"`
 
@@ -1265,12 +1264,12 @@ func (gl *List) Error() error {
 //
 // Example:
 //
-//     var RowType = new Object({
-//       name: 'Row',
-//       fields: () => ({
-//         id: { type: new NonNull(String) },
-//       })
-//     })
+//	var RowType = new Object({
+//	  name: 'Row',
+//	  fields: () => ({
+//	    id: { type: new NonNull(String) },
+//	  })
+//	})
 //
 // Note: the enforcement of non-nullability occurs within the executor.
 type NonNull struct {

--- a/directives_test.go
+++ b/directives_test.go
@@ -616,6 +616,13 @@ var fieldDefinitionDirectivesTestSchema, _ = graphql.NewSchema(graphql.SchemaCon
 						},
 					},
 				}),
+				Resolve: func(ctx context.Context, p graphql.ResolveParams) (interface{}, error) {
+					return struct {
+						b string `json:"b"`
+					}{
+						b: "b",
+					}, nil
+				},
 				Directives: []*ast.Directive{
 					{
 						Name: &ast.Name{Value: "fieldDefDirective"},


### PR DESCRIPTION
https://app.asana.com/0/1182291590501927/1205474699889736/f

This change implements SOME support for directives in our GQL library and adds hooks to handle directives at runtime. It also adds a gen time assertion regarding allow identity usage.

Field Def Directive/Handler Support:
![image](https://github.com/sprucehealth/graphql/assets/348420/36ef0de9-5eae-4c0c-a96c-80f72c76c630)
![image](https://github.com/sprucehealth/graphql/assets/348420/766d8309-650a-429c-ab21-b5ab649d87c2)

Gen time checks: (This is a bit of a hack putting it right into the generator, but we are moving away from this soon anyways)
![image](https://github.com/sprucehealth/graphql/assets/348420/f29638ff-30de-4c66-910c-1317bad35741)


Current "Hacks":
* How the directive assertion system (making sure all relevant fields are explicitly annotated) is a part of the generator itself rather than having the generator expose some sort of API/Config hooks to wire that in.

* The rendering of ast.Value currently only supports Boolean arguments in directives. There are lots of other types that match that interface, but none of our directives currently use them.