### PR TITLE
Include trace in all non-formatted errors.

### DIFF
--- a/abstract_test.go
+++ b/abstract_test.go
@@ -385,6 +385,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		t.Fatalf("wrong result, expected errors: %v, got: %v", len(expected.Errors), len(result.Errors))
 	}
 	result.Errors[0].OriginalError = nil
+	result.Errors[0].StackTrace = ""
 	if !reflect.DeepEqual(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
@@ -504,6 +505,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 		t.Fatalf("wrong result, expected errors: %v, got: %v", len(expected.Errors), len(result.Errors))
 	}
 	result.Errors[0].OriginalError = nil
+	result.Errors[0].StackTrace = ""
 	if !reflect.DeepEqual(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}

--- a/directives_test.go
+++ b/directives_test.go
@@ -3,12 +3,12 @@ package graphql_test
 import (
 	"context"
 	"errors"
-	"github.com/sprucehealth/graphql/language/ast"
 	"reflect"
 	"testing"
 
 	"github.com/sprucehealth/graphql"
 	"github.com/sprucehealth/graphql/gqlerrors"
+	"github.com/sprucehealth/graphql/language/ast"
 	"github.com/sprucehealth/graphql/language/location"
 	"github.com/sprucehealth/graphql/testutil"
 )
@@ -65,7 +65,9 @@ func TestDirectives_DirectivesMustBeNamed(t *testing.T) {
 		Type:          "INTERNAL",
 		OriginalError: errors.New("Directive must be named."),
 	}
-	if !reflect.DeepEqual(expectedErr, err) {
+	e := err.(gqlerrors.FormattedError)
+	e.StackTrace = ""
+	if !reflect.DeepEqual(expectedErr, e) {
 		t.Fatalf("Expected error to be equal, got: %v", testutil.Diff(expectedErr, err))
 	}
 }
@@ -94,7 +96,9 @@ func TestDirectives_DirectiveNameMustBeValid(t *testing.T) {
 		Type:          "INTERNAL",
 		OriginalError: errors.New("Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"123invalid name\" does not."),
 	}
-	if !reflect.DeepEqual(expectedErr, err) {
+	e := err.(gqlerrors.FormattedError)
+	e.StackTrace = ""
+	if !reflect.DeepEqual(expectedErr, e) {
 		t.Fatalf("Expected error to be equal, got: %v", testutil.Diff(expectedErr, err))
 	}
 }
@@ -120,7 +124,9 @@ func TestDirectives_DirectiveNameMustProvideLocations(t *testing.T) {
 		Type:          "INTERNAL",
 		OriginalError: errors.New("Must provide locations for directive."),
 	}
-	if !reflect.DeepEqual(expectedErr, err) {
+	e := err.(gqlerrors.FormattedError)
+	e.StackTrace = ""
+	if !reflect.DeepEqual(expectedErr, e) {
 		t.Fatalf("Expected error to be equal, got: %v", testutil.Diff(expectedErr, err))
 	}
 }
@@ -159,7 +165,9 @@ func TestDirectives_DirectiveArgNamesMustBeValid(t *testing.T) {
 		Type:          "INTERNAL",
 		OriginalError: errors.New("Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"123if\" does not."),
 	}
-	if !reflect.DeepEqual(expectedErr, err) {
+	e := err.(gqlerrors.FormattedError)
+	e.StackTrace = ""
+	if !reflect.DeepEqual(expectedErr, e) {
 		t.Fatalf("Expected error to be equal, got: %v", testutil.Diff(expectedErr, err))
 	}
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -878,6 +878,7 @@ func TestThrowsIfNoOperationIsProvided(t *testing.T) {
 		t.Fatalf("wrong result, expected nil result.Data, got %v", result.Data)
 	}
 	result.Errors[0].OriginalError = nil
+	result.Errors[0].StackTrace = ""
 	if !reflect.DeepEqual(expectedErrors, result.Errors) {
 		t.Fatalf("unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}
@@ -928,6 +929,7 @@ func TestThrowsIfNoOperationNameIsProvidedWithMultipleOperations(t *testing.T) {
 		t.Fatalf("wrong result, expected nil result.Data, got %v", result.Data)
 	}
 	result.Errors[0].OriginalError = nil
+	result.Errors[0].StackTrace = ""
 	if !reflect.DeepEqual(expectedErrors, result.Errors) {
 		t.Fatalf("unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}
@@ -976,6 +978,7 @@ func TestThrowsIfUnknownOperationNameIsProvided(t *testing.T) {
 		t.Fatalf("wrong result, expected nil result.Data, got %v", result.Data)
 	}
 	result.Errors[0].OriginalError = nil
+	result.Errors[0].StackTrace = ""
 	if !reflect.DeepEqual(expectedErrors, result.Errors) {
 		t.Fatalf("unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}
@@ -1487,6 +1490,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
 	result.Errors[0].OriginalError = nil
+	result.Errors[0].StackTrace = ""
 	if !reflect.DeepEqual(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
@@ -1536,6 +1540,7 @@ func TestFailsToExecuteQueryContainingATypeDefinition(t *testing.T) {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}
 	result.Errors[0].OriginalError = nil
+	result.Errors[0].StackTrace = ""
 	if !reflect.DeepEqual(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
@@ -1874,6 +1879,7 @@ func TestContextDeadline(t *testing.T) {
 		t.Fatalf("Result should include errors when deadline is exceeded")
 	}
 	result.Errors[0].OriginalError = nil
+	result.Errors[0].StackTrace = ""
 	if !reflect.DeepEqual(expectedErrors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}
@@ -1930,6 +1936,7 @@ func TestContextDeadlineWait(t *testing.T) {
 		t.Fatalf("Result should include errors when deadline is exceeded")
 	}
 	result.Errors[0].OriginalError = nil
+	result.Errors[0].StackTrace = ""
 	if !reflect.DeepEqual(expectedErrors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}
@@ -2014,6 +2021,7 @@ func TestContextCancel(t *testing.T) {
 		t.Fatalf("Result should include errors when deadline is exceeded")
 	}
 	result.Errors[0].OriginalError = nil
+	result.Errors[0].StackTrace = ""
 	if !reflect.DeepEqual(expectedErrors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}

--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -57,6 +57,7 @@ func FormatError(err error) FormattedError {
 			Type:          ErrorTypeInternal,
 			Message:       err.Error(),
 			Locations:     []location.SourceLocation{},
+			StackTrace:    stackTrace(),
 			OriginalError: err,
 		}
 	}

--- a/lists_test.go
+++ b/lists_test.go
@@ -56,6 +56,7 @@ func checkList(t *testing.T, testType graphql.Type, testData interface{}, expect
 	}
 	for i := range result.Errors {
 		result.Errors[i].OriginalError = nil
+		result.Errors[i].StackTrace = ""
 	}
 	if !reflect.DeepEqual(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))


### PR DESCRIPTION
For any error that's not explicitly formatted include the stacktrace. These errors are internal and unexpected so the trace helps to know where they happen.