### PR TITLE
Optionally run custom resolvers in coroutines

### DIFF
--- a/coroutines.go
+++ b/coroutines.go
@@ -1,0 +1,142 @@
+package graphql
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+type ctxCoroutineKey struct{}
+
+type coroutine struct {
+	mu       sync.Mutex
+	toCoCh   chan bool
+	fromCoCh chan coroutineState
+	done     bool
+}
+
+type coroutineState struct {
+	res  any
+	err  error
+	pan  any
+	done bool
+}
+
+var (
+	// ErrCoroutineStopped is returned from PauseCoroutine when a coroutine is stopped. The caller
+	// should propagate the error up as quickly as possible.
+	ErrCoroutineStopped = errors.New("graphql: coroutine stopped")
+	// ErrNoCoroutine is returned from PauseCoroutine when there's no coroutine in the context.
+	ErrNoCoroutine = errors.New("graphql: no coroutine")
+)
+
+func startCoroutine(ctx context.Context, fn func(ctx context.Context) (any, error)) *coroutine {
+	co := &coroutine{
+		toCoCh:   make(chan bool),
+		fromCoCh: make(chan coroutineState),
+	}
+	ctx = context.WithValue(ctx, ctxCoroutineKey{}, co)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil && !co.done {
+				co.done = true
+				co.fromCoCh <- coroutineState{
+					done: true,
+					pan:  r,
+				}
+			}
+		}()
+
+		// Wait for the initial run.
+		stop := <-co.toCoCh
+		if stop {
+			co.done = true
+			co.fromCoCh <- coroutineState{
+				done: true,
+				err:  ErrCoroutineStopped,
+			}
+			return
+		}
+		v, err := fn(ctx)
+		co.mu.Lock()
+		defer co.mu.Unlock()
+		co.done = true
+		co.fromCoCh <- coroutineState{
+			done: true,
+			res:  v,
+			err:  err,
+		}
+	}()
+	return co
+}
+
+func (c *coroutine) run() coroutineState {
+	if c.done {
+		return coroutineState{
+			err:  ErrCoroutineStopped,
+			done: true,
+		}
+	}
+	// Signal the coroutine go routine to start.
+	c.toCoCh <- false
+	// Wait for a response.
+	st := <-c.fromCoCh
+	// Propagate panics
+	if st.pan != nil {
+		panic(st.pan)
+	}
+	return st
+}
+
+func (c *coroutine) stop() {
+	if c.done {
+		return
+	}
+	// Signal the coroutine go routine to stop.
+	c.toCoCh <- true
+	// Wait for a response.
+	st := <-c.fromCoCh
+	// Propagate panics
+	if st.pan != nil {
+		panic(st.pan)
+	}
+}
+
+// HasCoroutine returns true if the context contains a coroutine.
+func HasCoroutine(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxCoroutineKey{}).(*coroutine)
+	return ok
+}
+
+// PauseCoroutine is called inside a coroutine and pauses execution returning
+// control the parent. It returns ErrNoCoroutine when there's no coroutine in the
+// context and ErrCoroutineStopped if the coroutine is stopped.
+func PauseCoroutine(ctx context.Context) error {
+	c, ok := ctx.Value(ctxCoroutineKey{}).(*coroutine)
+	if !ok {
+		return ErrNoCoroutine
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.done {
+		return ErrCoroutineStopped
+	}
+	c.fromCoCh <- coroutineState{res: nil, done: false}
+	stop := <-c.toCoCh
+	if stop {
+		c.done = true
+		return ErrCoroutineStopped
+	}
+	return nil
+}
+
+// DisconnectCoroutine removes any coroutine from the context. This should be used
+// when passing the context to a goroutine that runs concurrently with other code
+// that may use the coroutine.
+func DisconnectCoroutine(ctx context.Context) context.Context {
+	_, ok := ctx.Value(ctxCoroutineKey{}).(*coroutine)
+	if !ok {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxCoroutineKey{}, nil)
+}

--- a/coroutines_test.go
+++ b/coroutines_test.go
@@ -1,0 +1,183 @@
+package graphql
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestCoroutines(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no pause", func(t *testing.T) {
+		co := startCoroutine(ctx, func(ctx context.Context) (any, error) {
+			return "Hello", nil
+		})
+		st := co.run()
+		if !st.done {
+			t.Fatal("Expected done state")
+		}
+		if st.res != "Hello" {
+			t.Fatalf("Expected \"Hello\" got %q", st.res)
+		}
+		if st.err != nil {
+			t.Fatal("Expected nil error")
+		}
+	})
+
+	t.Run("pause", func(t *testing.T) {
+		co := startCoroutine(ctx, func(ctx context.Context) (any, error) {
+			if err := PauseCoroutine(ctx); err != nil {
+				return nil, err
+			}
+			return "World", nil
+		})
+		st := co.run()
+		if st.done {
+			t.Fatal("Expected not done state")
+		}
+		if st.res != nil {
+			t.Fatalf("Expected nil got %v", st.res)
+		}
+		if st.err != nil {
+			t.Fatal("Expected nil error")
+		}
+		st = co.run()
+		if !st.done {
+			t.Fatal("Expected done state")
+		}
+		if st.res != "World" {
+			t.Fatalf("Expected \"World\" got %v", st.res)
+		}
+		if st.err != nil {
+			t.Fatal("Expected nil error")
+		}
+	})
+
+	t.Run("stop before start", func(t *testing.T) {
+		i := 1
+		co := startCoroutine(ctx, func(ctx context.Context) (any, error) {
+			i = 2
+			if err := PauseCoroutine(ctx); err != nil {
+				return nil, err
+			}
+			return "World", nil
+		})
+		co.stop()
+		if i != 1 {
+			t.Fatal("Coroutine executed when it should have stopped")
+		}
+	})
+
+	t.Run("stop", func(t *testing.T) {
+		i := 1
+		co := startCoroutine(ctx, func(ctx context.Context) (any, error) {
+			i = 2
+			if err := PauseCoroutine(ctx); err != nil {
+				return nil, err
+			}
+			i = 3
+			return "World", nil
+		})
+		st := co.run()
+		if st.done {
+			t.Fatal("Expected not done state")
+		}
+		if st.res != nil {
+			t.Fatalf("Expected nil got %v", st.res)
+		}
+		if st.err != nil {
+			t.Fatal("Expected nil error")
+		}
+		if i != 2 {
+			t.Fatal("Coroutine should have pause")
+		}
+		co.stop()
+		if i != 2 {
+			t.Fatal("Coroutine should have stopped at pause")
+		}
+	})
+}
+
+func BenchmarkCoroutineInit(b *testing.B) {
+	ctx := context.Background()
+
+	fn := func(ctx context.Context) (any, error) {
+		return "Hello", nil
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		co := startCoroutine(ctx, fn)
+		st := co.run()
+		if !st.done {
+			b.Fatal("Expected done state")
+		}
+		if st.res != "Hello" {
+			b.Fatalf("Expected \"Hello\" got %q", st.res)
+		}
+		if st.err != nil {
+			b.Fatal("Expected nil error")
+		}
+	}
+}
+
+func TestCoroutineContext(t *testing.T) {
+	ctx := context.Background()
+	co := startCoroutine(ctx, func(ctx context.Context) (any, error) {
+		if !HasCoroutine(ctx) {
+			return "", errors.New("expected a coroutine")
+		}
+		if HasCoroutine(DisconnectCoroutine(ctx)) {
+			return "", errors.New("did not expect coroutine")
+		}
+		return "Hello", nil
+	})
+	st := co.run()
+	if !st.done {
+		t.Fatal("Expected coroutine to complete")
+	}
+	if st.err != nil {
+		t.Fatal(st.err)
+	}
+}
+
+func BenchmarkCoroutinePause(b *testing.B) {
+	ctx := context.Background()
+
+	co := startCoroutine(ctx, func(ctx context.Context) (any, error) {
+		for range b.N {
+			_ = PauseCoroutine(ctx)
+		}
+		return "World", nil
+	})
+	b.ResetTimer()
+	b.ReportAllocs()
+	var st coroutineState
+	for range b.N {
+		st = co.run()
+		if st.done {
+			b.Fatal("Expected not done state")
+		}
+	}
+	if st.done {
+		b.Fatal("Expected not done state")
+	}
+	if st.res != nil {
+		b.Fatalf("Expected nil got %v", st.res)
+	}
+	if st.err != nil {
+		b.Fatal("Expected nil error")
+	}
+	st = co.run()
+	if !st.done {
+		b.Fatal("Expected done state")
+	}
+	if st.res != "World" {
+		b.Fatalf("Expected \"World\" got %v", st.res)
+	}
+	if st.err != nil {
+		b.Fatal("Expected nil error")
+	}
+}

--- a/executor.go
+++ b/executor.go
@@ -610,13 +610,8 @@ func completeValue(ctx context.Context, eCtx *ExecutionContext, returnType Type,
 	if err := ctx.Err(); err != nil {
 		panic(gqlerrors.FormatError(err))
 	}
-
-	resultVal := reflect.ValueOf(result)
-	if resultVal.IsValid() && resultVal.Type().Kind() == reflect.Func {
-		if propertyFn, ok := result.(func() any); ok {
-			return propertyFn()
-		}
-		panic(gqlerrors.NewFormattedError("Error resolving func. Expected `func() any` signature"))
+	if propertyFn, ok := result.(func() any); ok {
+		return propertyFn()
 	}
 
 	// If field type is NonNull, complete for inner type, and throw field error

--- a/executor_bench_test.go
+++ b/executor_bench_test.go
@@ -93,7 +93,7 @@ func BenchmarkDefaultResolveFnStruct(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := defaultResolveFn(context.Background(), p); err != nil {
 			b.Fatal(err)
 		}
@@ -119,14 +119,14 @@ func BenchmarkDefaultResolveFnMap(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := defaultResolveFn(context.Background(), p); err != nil {
 			b.Fatal(err)
 		}
 	}
 }
 
-func BenchmarkQuery(b *testing.B) {
+func benchmarkQuery(b *testing.B, coroutines bool) {
 	type enumValueType string
 
 	const enumValue enumValueType = "foo"
@@ -205,16 +205,25 @@ func BenchmarkQuery(b *testing.B) {
 	}
 
 	ep := ExecuteParams{
-		Schema: schema,
-		AST:    astDoc,
+		Schema:           schema,
+		AST:              astDoc,
+		EnableCoroutines: coroutines,
 	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		result := Execute(context.Background(), ep)
 		if len(result.Errors) > 0 {
 			b.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 		}
 	}
+}
+
+func BenchmarkQuery(b *testing.B) {
+	benchmarkQuery(b, false)
+}
+
+func BenchmarkQueryCoroutines(b *testing.B) {
+	benchmarkQuery(b, true)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sprucehealth/graphql
 
-go 1.24
+go 1.25
 
 require github.com/kr/pretty v0.3.1
 

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -2,9 +2,7 @@ package graphql_test
 
 import (
 	"reflect"
-	"strings"
 	"testing"
-	"time"
 
 	"context"
 
@@ -261,74 +259,5 @@ func TestBoolPointer(t *testing.T) {
 		if !reflect.DeepEqual(result.Data, expected) {
 			t.Fatalf("wrong result, query: %v, graphql result diff: %v", query, testutil.Diff(expected, result.Data))
 		}
-	}
-}
-
-func TestTracing(t *testing.T) {
-	schema, err := graphql.NewSchema(graphql.SchemaConfig{
-		Query: graphql.NewObject(graphql.ObjectConfig{
-			Name: "RootQueryType",
-			Fields: graphql.Fields{
-				"object": &graphql.Field{
-					Type: graphql.NewNonNull(graphql.NewObject(graphql.ObjectConfig{
-						Name: "First",
-						Fields: graphql.Fields{
-							"first": &graphql.Field{
-								Type: graphql.NewNonNull(graphql.NewList(graphql.NewObject(graphql.ObjectConfig{
-									Name: "Seconds",
-									Fields: graphql.Fields{
-										"second": &graphql.Field{
-											Type: graphql.Boolean,
-											Resolve: func(ctx context.Context, p graphql.ResolveParams) (any, error) {
-												return true, nil
-											},
-										},
-									},
-								}))),
-								Resolve: func(ctx context.Context, p graphql.ResolveParams) (any, error) {
-									return []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, nil
-								},
-							},
-						},
-					})),
-					Resolve: func(ctx context.Context, p graphql.ResolveParams) (any, error) {
-						return true, nil
-					},
-				},
-			},
-		}),
-	})
-	if err != nil {
-		t.Fatalf("wrong result, unexpected errors: %v", err.Error())
-	}
-	query := "{ object { first { second }} }"
-
-	for range 10 {
-		tr := graphql.NewCountingTracer(true)
-		result := graphql.Do(context.Background(), graphql.Params{
-			Schema:        schema,
-			RequestString: query,
-			Tracer:        tr,
-		})
-		if len(result.Errors) > 0 {
-			t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
-		}
-		var traces []*graphql.TracePathCount
-		for _, tr := range tr.IterTraces() {
-			t.Logf("%s %d executions, %s total duration, %s max duration, %s average duration\n",
-				strings.Join(tr.Path, "."), tr.Count, tr.TotalDuration, tr.MaxDuration, tr.TotalDuration/time.Duration(tr.Count))
-			traces = append(traces, tr)
-		}
-		if len(traces) != 3 {
-			t.Logf("Expected 3 traces, got %d", len(traces))
-		}
-		// Assume the order of execution which should always be consistent unless the executor changes.
-		for i, expCount := range []int{1, 1, 10} {
-			trace := traces[i]
-			if trace.Count != expCount {
-				t.Logf("Expected count of %d for %v, got %d", expCount, trace.Path, trace.Count)
-			}
-		}
-		tr.Recycle()
 	}
 }

--- a/introspection.go
+++ b/introspection.go
@@ -22,493 +22,465 @@ const (
 	TypeKindNonNull     = "NON_NULL"
 )
 
-// SchemaType is type definition for __Schema
-var SchemaType *Object
-
-// DirectiveType is type definition for __Directive
-var DirectiveType *Object
-
-// TypeType is type definition for __Type
-var TypeType *Object
-
-// FieldType is type definition for __Field
-var FieldType *Object
-
-// InputValueType is type definition for __InputValue
-var InputValueType *Object
-
-// EnumValueType is type definition for __EnumValue
-var EnumValueType *Object
-
 // TypeKindEnumType is type definition for __TypeKind
-var TypeKindEnumType *Enum
+var TypeKindEnumType = NewEnum(EnumConfig{
+	Name:        "__TypeKind",
+	Description: "An enum describing what kind of type a given `__Type` is",
+	Values: EnumValueConfigMap{
+		"SCALAR": &EnumValueConfig{
+			Value:       TypeKindScalar,
+			Description: "Indicates this type is a scalar.",
+		},
+		"OBJECT": &EnumValueConfig{
+			Value: TypeKindObject,
+			Description: "Indicates this type is an object. " +
+				"`fields` and `interfaces` are valid fields.",
+		},
+		"INTERFACE": &EnumValueConfig{
+			Value: TypeKindInterface,
+			Description: "Indicates this type is an interface. " +
+				"`fields` and `possibleTypes` are valid fields.",
+		},
+		"UNION": &EnumValueConfig{
+			Value: TypeKindUnion,
+			Description: "Indicates this type is a union. " +
+				"`possibleTypes` is a valid field.",
+		},
+		"ENUM": &EnumValueConfig{
+			Value: TypeKindEnum,
+			Description: "Indicates this type is an enum. " +
+				"`enumValues` is a valid field.",
+		},
+		"INPUT_OBJECT": &EnumValueConfig{
+			Value: TypeKindInputObject,
+			Description: "Indicates this type is an input object. " +
+				"`inputFields` is a valid field.",
+		},
+		"LIST": &EnumValueConfig{
+			Value: TypeKindList,
+			Description: "Indicates this type is a list. " +
+				"`ofType` is a valid field.",
+		},
+		"NON_NULL": &EnumValueConfig{
+			Value: TypeKindNonNull,
+			Description: "Indicates this type is a non-null. " +
+				"`ofType` is a valid field.",
+		},
+	},
+})
 
 // DirectiveLocationEnumType is type definition for __DirectiveLocation
-var DirectiveLocationEnumType *Enum
+var DirectiveLocationEnumType = NewEnum(EnumConfig{
+	Name: "__DirectiveLocation",
+	Description: "A Directive can be adjacent to many parts of the GraphQL language, a " +
+		"__DirectiveLocation describes one such possible adjacencies.",
+	Values: EnumValueConfigMap{
+		"QUERY": &EnumValueConfig{
+			Value:       DirectiveLocationQuery,
+			Description: "Location adjacent to a query operation.",
+		},
+		"MUTATION": &EnumValueConfig{
+			Value:       DirectiveLocationMutation,
+			Description: "Location adjacent to a mutation operation.",
+		},
+		"SUBSCRIPTION": &EnumValueConfig{
+			Value:       DirectiveLocationSubscription,
+			Description: "Location adjacent to a subscription operation.",
+		},
+		"FIELD": &EnumValueConfig{
+			Value:       DirectiveLocationField,
+			Description: "Location adjacent to a field.",
+		},
+		"FRAGMENT_DEFINITION": &EnumValueConfig{
+			Value:       DirectiveLocationFragmentDefinition,
+			Description: "Location adjacent to a fragment definition.",
+		},
+		"FRAGMENT_SPREAD": &EnumValueConfig{
+			Value:       DirectiveLocationFragmentSpread,
+			Description: "Location adjacent to a fragment spread.",
+		},
+		"INLINE_FRAGMENT": &EnumValueConfig{
+			Value:       DirectiveLocationInlineFragment,
+			Description: "Location adjacent to an inline fragment.",
+		},
+		"SCHEMA": &EnumValueConfig{
+			Value:       DirectiveLocationSchema,
+			Description: "Location adjacent to a schema definition.",
+		},
+		"SCALAR": &EnumValueConfig{
+			Value:       DirectiveLocationScalar,
+			Description: "Location adjacent to a scalar definition.",
+		},
+		"OBJECT": &EnumValueConfig{
+			Value:       DirectiveLocationObject,
+			Description: "Location adjacent to a object definition.",
+		},
+		"FIELD_DEFINITION": &EnumValueConfig{
+			Value:       DirectiveLocationFieldDefinition,
+			Description: "Location adjacent to a field definition.",
+		},
+		"ARGUMENT_DEFINITION": &EnumValueConfig{
+			Value:       DirectiveLocationArgumentDefinition,
+			Description: "Location adjacent to an argument definition.",
+		},
+		"INTERFACE": &EnumValueConfig{
+			Value:       DirectiveLocationInterface,
+			Description: "Location adjacent to an interface definition.",
+		},
+		"UNION": &EnumValueConfig{
+			Value:       DirectiveLocationUnion,
+			Description: "Location adjacent to a union definition.",
+		},
+		"ENUM": &EnumValueConfig{
+			Value:       DirectiveLocationEnum,
+			Description: "Location adjacent to an enum definition.",
+		},
+		"ENUM_VALUE": &EnumValueConfig{
+			Value:       DirectiveLocationEnumValue,
+			Description: "Location adjacent to an enum value definition.",
+		},
+		"INPUT_OBJECT": &EnumValueConfig{
+			Value:       DirectiveLocationInputObject,
+			Description: "Location adjacent to an input object type definition.",
+		},
+		"INPUT_FIELD_DEFINITION": &EnumValueConfig{
+			Value:       DirectiveLocationInputFieldDefinition,
+			Description: "Location adjacent to an input object field definition.",
+		},
+	},
+})
 
-// Meta-field definitions.
+// TypeType is type definition for __Type
+var TypeType = NewObject(ObjectConfig{
+	Name: "__Type",
+	Description: "The fundamental unit of any GraphQL Schema is the type. There are " +
+		"many kinds of types in GraphQL as represented by the `__TypeKind` enum." +
+		"\n\nDepending on the kind of a type, certain fields describe " +
+		"information about that type. Scalar types provide no information " +
+		"beyond a name and description, while Enum types provide their values. " +
+		"Object and Interface types provide the fields they describe. Abstract " +
+		"types, Union and Interface, provide the Object types possible " +
+		"at runtime. List and NonNull types compose other types.",
 
-// SchemaMetaFieldDef Meta field definition for Schema
-var SchemaMetaFieldDef *FieldDefinition
+	Fields: Fields{
+		"kind": &Field{
+			Type: NewNonNull(TypeKindEnumType),
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				switch p.Source.(type) {
+				case *Scalar:
+					return TypeKindScalar, nil
+				case *Object:
+					return TypeKindObject, nil
+				case *Interface:
+					return TypeKindInterface, nil
+				case *Union:
+					return TypeKindUnion, nil
+				case *Enum:
+					return TypeKindEnum, nil
+				case *InputObject:
+					return TypeKindInputObject, nil
+				case *List:
+					return TypeKindList, nil
+				case *NonNull:
+					return TypeKindNonNull, nil
+				}
+				return nil, fmt.Errorf("graphql: unknown kind of type: %v", p.Source)
+			},
+		},
+		"name": &Field{
+			Type: String,
+		},
+		"description": &Field{
+			Type: String,
+		},
+		"fields":        &Field{},
+		"interfaces":    &Field{},
+		"possibleTypes": &Field{},
+		"enumValues":    &Field{},
+		"inputFields":   &Field{},
+		"ofType":        &Field{},
+	},
+})
 
-// TypeMetaFieldDef Meta field definition for types
-var TypeMetaFieldDef *FieldDefinition
+// InputValueType is type definition for __InputValue
+var InputValueType = NewObject(ObjectConfig{
+	Name: "__InputValue",
+	Description: "Arguments provided to Fields or Directives and the input fields of an " +
+		"InputObject are represented as Input Values which describe their type " +
+		"and optionally a default value.",
+	Fields: Fields{
+		"name": &Field{
+			Type: NewNonNull(String),
+		},
+		"description": &Field{
+			Type: String,
+		},
+		"type": &Field{
+			Type: NewNonNull(TypeType),
+		},
+		"defaultValue": &Field{
+			Type: String,
+			Description: "A GraphQL-formatted string representing the default value for this " +
+				"input value.",
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				if inputVal, ok := p.Source.(*Argument); ok {
+					if inputVal.DefaultValue == nil {
+						return nil, nil
+					}
+					if isNullish(inputVal.DefaultValue) {
+						return nil, nil
+					}
+					astVal := astFromValue(inputVal.DefaultValue, inputVal)
+					return printer.Print(astVal), nil
+				}
+				if inputVal, ok := p.Source.(*InputObjectField); ok {
+					if inputVal.DefaultValue == nil {
+						return nil, nil
+					}
+					astVal := astFromValue(inputVal.DefaultValue, inputVal)
+					return printer.Print(astVal), nil
+				}
+				return nil, nil
+			},
+		},
+	},
+})
 
-// TypeNameMetaFieldDef Meta field definition for type names
-var TypeNameMetaFieldDef *FieldDefinition
+// FieldType is type definition for __Field
+var FieldType = NewObject(ObjectConfig{
+	Name: "__Field",
+	Description: "Object and Interface types are described by a list of Fields, each of " +
+		"which has a name, potentially a list of arguments, and a return type.",
+	Fields: Fields{
+		"name": &Field{
+			Type: NewNonNull(String),
+		},
+		"description": &Field{
+			Type: String,
+		},
+		"args": &Field{
+			Type: NewNonNull(NewList(NewNonNull(InputValueType))),
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				if field, ok := p.Source.(*FieldDefinition); ok {
+					args := append([]*Argument(nil), field.Args...)
+					sort.Slice(args, func(i, j int) bool {
+						return args[i].Name() < args[j].Name()
+					})
+					return args, nil
+				}
+				return []any{}, nil
+			},
+		},
+		"type": &Field{
+			Type: NewNonNull(TypeType),
+		},
+		"isDeprecated": &Field{
+			Type: NewNonNull(Boolean),
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				if field, ok := p.Source.(*FieldDefinition); ok {
+					return field.DeprecationReason != "", nil
+				}
+				return false, nil
+			},
+		},
+		"deprecationReason": &Field{
+			Type: String,
+		},
+	},
+})
+
+// DirectiveType is type definition for __Directive
+var DirectiveType = NewObject(ObjectConfig{
+	Name: "__Directive",
+	Description: "A Directive provides a way to describe alternate runtime execution and " +
+		"type validation behavior in a GraphQL document. " +
+		"\n\nIn some cases, you need to provide options to alter GraphQL's " +
+		"execution behavior in ways field arguments will not suffice, such as " +
+		"conditionally including or skipping a field. Directives provide this by " +
+		"describing additional information to the executor.",
+	Fields: Fields{
+		"name": &Field{
+			Type: NewNonNull(String),
+		},
+		"description": &Field{
+			Type: String,
+		},
+		"locations": &Field{
+			Type: NewNonNull(NewList(
+				NewNonNull(DirectiveLocationEnumType),
+			)),
+		},
+		"args": &Field{
+			Type: NewNonNull(NewList(
+				NewNonNull(InputValueType),
+			)),
+		},
+		// NOTE: the following three fields are deprecated and are no longer part
+		// of the GraphQL specification.
+		"onOperation": &Field{
+			DeprecationReason: "Use `locations`.",
+			Type:              NewNonNull(Boolean),
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				if dir, ok := p.Source.(*Directive); ok {
+					res := false
+					for _, loc := range dir.Locations {
+						if loc == DirectiveLocationQuery ||
+							loc == DirectiveLocationMutation ||
+							loc == DirectiveLocationSubscription {
+							res = true
+							break
+						}
+					}
+					return res, nil
+				}
+				return false, nil
+			},
+		},
+		"onFragment": &Field{
+			DeprecationReason: "Use `locations`.",
+			Type:              NewNonNull(Boolean),
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				if dir, ok := p.Source.(*Directive); ok {
+					res := false
+					for _, loc := range dir.Locations {
+						if loc == DirectiveLocationFragmentSpread ||
+							loc == DirectiveLocationInlineFragment ||
+							loc == DirectiveLocationFragmentDefinition {
+							res = true
+							break
+						}
+					}
+					return res, nil
+				}
+				return false, nil
+			},
+		},
+		"onField": &Field{
+			DeprecationReason: "Use `locations`.",
+			Type:              NewNonNull(Boolean),
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				if dir, ok := p.Source.(*Directive); ok {
+					res := false
+					for _, loc := range dir.Locations {
+						if loc == DirectiveLocationField {
+							res = true
+							break
+						}
+					}
+					return res, nil
+				}
+				return false, nil
+			},
+		},
+	},
+})
+
+// SchemaType is type definition for __Schema
+var SchemaType = NewObject(ObjectConfig{
+	Name: "__Schema",
+	Description: `A GraphQL Schema defines the capabilities of a GraphQL server. ` +
+		`It exposes all available types and directives on the server, as well as ` +
+		`the entry points for query, mutation, and subscription operations.`,
+	Fields: Fields{
+		"types": &Field{
+			Description: "A list of all types supported by this server.",
+			Type: NewNonNull(NewList(
+				NewNonNull(TypeType),
+			)),
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				if schema, ok := p.Source.(Schema); ok {
+					var results []Type
+					for _, ttype := range schema.TypeMap() {
+						results = append(results, ttype)
+					}
+					sort.Slice(results, func(i, j int) bool {
+						return results[i].Name() < results[j].Name()
+					})
+					return results, nil
+				}
+				return []Type{}, nil
+			},
+		},
+		"queryType": &Field{
+			Description: "The type that query operations will be rooted at.",
+			Type:        NewNonNull(TypeType),
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				if schema, ok := p.Source.(Schema); ok {
+					return schema.QueryType(), nil
+				}
+				return nil, nil
+			},
+		},
+		"mutationType": &Field{
+			Description: `If this server supports mutation, the type that ` +
+				`mutation operations will be rooted at.`,
+			Type: TypeType,
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				if schema, ok := p.Source.(Schema); ok {
+					if schema.MutationType() != nil {
+						return schema.MutationType(), nil
+					}
+				}
+				return nil, nil
+			},
+		},
+		"subscriptionType": &Field{
+			Description: `If this server supports subscription, the type that ` +
+				`subscription operations will be rooted at.`,
+			Type: TypeType,
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				if schema, ok := p.Source.(Schema); ok {
+					if schema.SubscriptionType() != nil {
+						return schema.SubscriptionType(), nil
+					}
+				}
+				return nil, nil
+			},
+		},
+		"directives": &Field{
+			Description: `A list of all directives supported by this server.`,
+			Type: NewNonNull(NewList(
+				NewNonNull(DirectiveType),
+			)),
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				if schema, ok := p.Source.(Schema); ok {
+					return schema.Directives(), nil
+				}
+				return nil, nil
+			},
+		},
+	},
+})
+
+// EnumValueType is type definition for __EnumValue
+var EnumValueType = NewObject(ObjectConfig{
+	Name: "__EnumValue",
+	Description: "One possible value for a given Enum. Enum values are unique values, not " +
+		"a placeholder for a string or numeric value. However an Enum value is " +
+		"returned in a JSON response as a string.",
+	Fields: Fields{
+		"name": &Field{
+			Type: NewNonNull(String),
+		},
+		"description": &Field{
+			Type: String,
+		},
+		"isDeprecated": &Field{
+			Type: NewNonNull(Boolean),
+			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+				if field, ok := p.Source.(*EnumValueDefinition); ok {
+					return field.DeprecationReason != "", nil
+				}
+				return false, nil
+			},
+		},
+		"deprecationReason": &Field{
+			Type: String,
+		},
+	},
+})
 
 func init() {
-	TypeKindEnumType = NewEnum(EnumConfig{
-		Name:        "__TypeKind",
-		Description: "An enum describing what kind of type a given `__Type` is",
-		Values: EnumValueConfigMap{
-			"SCALAR": &EnumValueConfig{
-				Value:       TypeKindScalar,
-				Description: "Indicates this type is a scalar.",
-			},
-			"OBJECT": &EnumValueConfig{
-				Value: TypeKindObject,
-				Description: "Indicates this type is an object. " +
-					"`fields` and `interfaces` are valid fields.",
-			},
-			"INTERFACE": &EnumValueConfig{
-				Value: TypeKindInterface,
-				Description: "Indicates this type is an interface. " +
-					"`fields` and `possibleTypes` are valid fields.",
-			},
-			"UNION": &EnumValueConfig{
-				Value: TypeKindUnion,
-				Description: "Indicates this type is a union. " +
-					"`possibleTypes` is a valid field.",
-			},
-			"ENUM": &EnumValueConfig{
-				Value: TypeKindEnum,
-				Description: "Indicates this type is an enum. " +
-					"`enumValues` is a valid field.",
-			},
-			"INPUT_OBJECT": &EnumValueConfig{
-				Value: TypeKindInputObject,
-				Description: "Indicates this type is an input object. " +
-					"`inputFields` is a valid field.",
-			},
-			"LIST": &EnumValueConfig{
-				Value: TypeKindList,
-				Description: "Indicates this type is a list. " +
-					"`ofType` is a valid field.",
-			},
-			"NON_NULL": &EnumValueConfig{
-				Value: TypeKindNonNull,
-				Description: "Indicates this type is a non-null. " +
-					"`ofType` is a valid field.",
-			},
-		},
-	})
-
-	DirectiveLocationEnumType = NewEnum(EnumConfig{
-		Name: "__DirectiveLocation",
-		Description: "A Directive can be adjacent to many parts of the GraphQL language, a " +
-			"__DirectiveLocation describes one such possible adjacencies.",
-		Values: EnumValueConfigMap{
-			"QUERY": &EnumValueConfig{
-				Value:       DirectiveLocationQuery,
-				Description: "Location adjacent to a query operation.",
-			},
-			"MUTATION": &EnumValueConfig{
-				Value:       DirectiveLocationMutation,
-				Description: "Location adjacent to a mutation operation.",
-			},
-			"SUBSCRIPTION": &EnumValueConfig{
-				Value:       DirectiveLocationSubscription,
-				Description: "Location adjacent to a subscription operation.",
-			},
-			"FIELD": &EnumValueConfig{
-				Value:       DirectiveLocationField,
-				Description: "Location adjacent to a field.",
-			},
-			"FRAGMENT_DEFINITION": &EnumValueConfig{
-				Value:       DirectiveLocationFragmentDefinition,
-				Description: "Location adjacent to a fragment definition.",
-			},
-			"FRAGMENT_SPREAD": &EnumValueConfig{
-				Value:       DirectiveLocationFragmentSpread,
-				Description: "Location adjacent to a fragment spread.",
-			},
-			"INLINE_FRAGMENT": &EnumValueConfig{
-				Value:       DirectiveLocationInlineFragment,
-				Description: "Location adjacent to an inline fragment.",
-			},
-			"SCHEMA": &EnumValueConfig{
-				Value:       DirectiveLocationSchema,
-				Description: "Location adjacent to a schema definition.",
-			},
-			"SCALAR": &EnumValueConfig{
-				Value:       DirectiveLocationScalar,
-				Description: "Location adjacent to a scalar definition.",
-			},
-			"OBJECT": &EnumValueConfig{
-				Value:       DirectiveLocationObject,
-				Description: "Location adjacent to a object definition.",
-			},
-			"FIELD_DEFINITION": &EnumValueConfig{
-				Value:       DirectiveLocationFieldDefinition,
-				Description: "Location adjacent to a field definition.",
-			},
-			"ARGUMENT_DEFINITION": &EnumValueConfig{
-				Value:       DirectiveLocationArgumentDefinition,
-				Description: "Location adjacent to an argument definition.",
-			},
-			"INTERFACE": &EnumValueConfig{
-				Value:       DirectiveLocationInterface,
-				Description: "Location adjacent to an interface definition.",
-			},
-			"UNION": &EnumValueConfig{
-				Value:       DirectiveLocationUnion,
-				Description: "Location adjacent to a union definition.",
-			},
-			"ENUM": &EnumValueConfig{
-				Value:       DirectiveLocationEnum,
-				Description: "Location adjacent to an enum definition.",
-			},
-			"ENUM_VALUE": &EnumValueConfig{
-				Value:       DirectiveLocationEnumValue,
-				Description: "Location adjacent to an enum value definition.",
-			},
-			"INPUT_OBJECT": &EnumValueConfig{
-				Value:       DirectiveLocationInputObject,
-				Description: "Location adjacent to an input object type definition.",
-			},
-			"INPUT_FIELD_DEFINITION": &EnumValueConfig{
-				Value:       DirectiveLocationInputFieldDefinition,
-				Description: "Location adjacent to an input object field definition.",
-			},
-		},
-	})
-
-	// Note: some fields (for e.g "fields", "interfaces") are defined later due to cyclic reference
-	TypeType = NewObject(ObjectConfig{
-		Name: "__Type",
-		Description: "The fundamental unit of any GraphQL Schema is the type. There are " +
-			"many kinds of types in GraphQL as represented by the `__TypeKind` enum." +
-			"\n\nDepending on the kind of a type, certain fields describe " +
-			"information about that type. Scalar types provide no information " +
-			"beyond a name and description, while Enum types provide their values. " +
-			"Object and Interface types provide the fields they describe. Abstract " +
-			"types, Union and Interface, provide the Object types possible " +
-			"at runtime. List and NonNull types compose other types.",
-
-		Fields: Fields{
-			"kind": &Field{
-				Type: NewNonNull(TypeKindEnumType),
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					switch p.Source.(type) {
-					case *Scalar:
-						return TypeKindScalar, nil
-					case *Object:
-						return TypeKindObject, nil
-					case *Interface:
-						return TypeKindInterface, nil
-					case *Union:
-						return TypeKindUnion, nil
-					case *Enum:
-						return TypeKindEnum, nil
-					case *InputObject:
-						return TypeKindInputObject, nil
-					case *List:
-						return TypeKindList, nil
-					case *NonNull:
-						return TypeKindNonNull, nil
-					}
-					return nil, fmt.Errorf("Unknown kind of type: %v", p.Source)
-				},
-			},
-			"name": &Field{
-				Type: String,
-			},
-			"description": &Field{
-				Type: String,
-			},
-			"fields":        &Field{},
-			"interfaces":    &Field{},
-			"possibleTypes": &Field{},
-			"enumValues":    &Field{},
-			"inputFields":   &Field{},
-			"ofType":        &Field{},
-		},
-	})
-
-	InputValueType = NewObject(ObjectConfig{
-		Name: "__InputValue",
-		Description: "Arguments provided to Fields or Directives and the input fields of an " +
-			"InputObject are represented as Input Values which describe their type " +
-			"and optionally a default value.",
-		Fields: Fields{
-			"name": &Field{
-				Type: NewNonNull(String),
-			},
-			"description": &Field{
-				Type: String,
-			},
-			"type": &Field{
-				Type: NewNonNull(TypeType),
-			},
-			"defaultValue": &Field{
-				Type: String,
-				Description: "A GraphQL-formatted string representing the default value for this " +
-					"input value.",
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					if inputVal, ok := p.Source.(*Argument); ok {
-						if inputVal.DefaultValue == nil {
-							return nil, nil
-						}
-						if isNullish(inputVal.DefaultValue) {
-							return nil, nil
-						}
-						astVal := astFromValue(inputVal.DefaultValue, inputVal)
-						return printer.Print(astVal), nil
-					}
-					if inputVal, ok := p.Source.(*InputObjectField); ok {
-						if inputVal.DefaultValue == nil {
-							return nil, nil
-						}
-						astVal := astFromValue(inputVal.DefaultValue, inputVal)
-						return printer.Print(astVal), nil
-					}
-					return nil, nil
-				},
-			},
-		},
-	})
-
-	FieldType = NewObject(ObjectConfig{
-		Name: "__Field",
-		Description: "Object and Interface types are described by a list of Fields, each of " +
-			"which has a name, potentially a list of arguments, and a return type.",
-		Fields: Fields{
-			"name": &Field{
-				Type: NewNonNull(String),
-			},
-			"description": &Field{
-				Type: String,
-			},
-			"args": &Field{
-				Type: NewNonNull(NewList(NewNonNull(InputValueType))),
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					if field, ok := p.Source.(*FieldDefinition); ok {
-						args := append([]*Argument(nil), field.Args...)
-						sort.Slice(args, func(i, j int) bool {
-							return args[i].Name() < args[j].Name()
-						})
-						return args, nil
-					}
-					return []any{}, nil
-				},
-			},
-			"type": &Field{
-				Type: NewNonNull(TypeType),
-			},
-			"isDeprecated": &Field{
-				Type: NewNonNull(Boolean),
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					if field, ok := p.Source.(*FieldDefinition); ok {
-						return field.DeprecationReason != "", nil
-					}
-					return false, nil
-				},
-			},
-			"deprecationReason": &Field{
-				Type: String,
-			},
-		},
-	})
-
-	DirectiveType = NewObject(ObjectConfig{
-		Name: "__Directive",
-		Description: "A Directive provides a way to describe alternate runtime execution and " +
-			"type validation behavior in a GraphQL document. " +
-			"\n\nIn some cases, you need to provide options to alter GraphQL's " +
-			"execution behavior in ways field arguments will not suffice, such as " +
-			"conditionally including or skipping a field. Directives provide this by " +
-			"describing additional information to the executor.",
-		Fields: Fields{
-			"name": &Field{
-				Type: NewNonNull(String),
-			},
-			"description": &Field{
-				Type: String,
-			},
-			"locations": &Field{
-				Type: NewNonNull(NewList(
-					NewNonNull(DirectiveLocationEnumType),
-				)),
-			},
-			"args": &Field{
-				Type: NewNonNull(NewList(
-					NewNonNull(InputValueType),
-				)),
-			},
-			// NOTE: the following three fields are deprecated and are no longer part
-			// of the GraphQL specification.
-			"onOperation": &Field{
-				DeprecationReason: "Use `locations`.",
-				Type:              NewNonNull(Boolean),
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					if dir, ok := p.Source.(*Directive); ok {
-						res := false
-						for _, loc := range dir.Locations {
-							if loc == DirectiveLocationQuery ||
-								loc == DirectiveLocationMutation ||
-								loc == DirectiveLocationSubscription {
-								res = true
-								break
-							}
-						}
-						return res, nil
-					}
-					return false, nil
-				},
-			},
-			"onFragment": &Field{
-				DeprecationReason: "Use `locations`.",
-				Type:              NewNonNull(Boolean),
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					if dir, ok := p.Source.(*Directive); ok {
-						res := false
-						for _, loc := range dir.Locations {
-							if loc == DirectiveLocationFragmentSpread ||
-								loc == DirectiveLocationInlineFragment ||
-								loc == DirectiveLocationFragmentDefinition {
-								res = true
-								break
-							}
-						}
-						return res, nil
-					}
-					return false, nil
-				},
-			},
-			"onField": &Field{
-				DeprecationReason: "Use `locations`.",
-				Type:              NewNonNull(Boolean),
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					if dir, ok := p.Source.(*Directive); ok {
-						res := false
-						for _, loc := range dir.Locations {
-							if loc == DirectiveLocationField {
-								res = true
-								break
-							}
-						}
-						return res, nil
-					}
-					return false, nil
-				},
-			},
-		},
-	})
-
-	SchemaType = NewObject(ObjectConfig{
-		Name: "__Schema",
-		Description: `A GraphQL Schema defines the capabilities of a GraphQL server. ` +
-			`It exposes all available types and directives on the server, as well as ` +
-			`the entry points for query, mutation, and subscription operations.`,
-		Fields: Fields{
-			"types": &Field{
-				Description: "A list of all types supported by this server.",
-				Type: NewNonNull(NewList(
-					NewNonNull(TypeType),
-				)),
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					if schema, ok := p.Source.(Schema); ok {
-						var results []Type
-						for _, ttype := range schema.TypeMap() {
-							results = append(results, ttype)
-						}
-						sort.Slice(results, func(i, j int) bool {
-							return results[i].Name() < results[j].Name()
-						})
-						return results, nil
-					}
-					return []Type{}, nil
-				},
-			},
-			"queryType": &Field{
-				Description: "The type that query operations will be rooted at.",
-				Type:        NewNonNull(TypeType),
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					if schema, ok := p.Source.(Schema); ok {
-						return schema.QueryType(), nil
-					}
-					return nil, nil
-				},
-			},
-			"mutationType": &Field{
-				Description: `If this server supports mutation, the type that ` +
-					`mutation operations will be rooted at.`,
-				Type: TypeType,
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					if schema, ok := p.Source.(Schema); ok {
-						if schema.MutationType() != nil {
-							return schema.MutationType(), nil
-						}
-					}
-					return nil, nil
-				},
-			},
-			"subscriptionType": &Field{
-				Description: `If this server supports subscription, the type that ` +
-					`subscription operations will be rooted at.`,
-				Type: TypeType,
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					if schema, ok := p.Source.(Schema); ok {
-						if schema.SubscriptionType() != nil {
-							return schema.SubscriptionType(), nil
-						}
-					}
-					return nil, nil
-				},
-			},
-			"directives": &Field{
-				Description: `A list of all directives supported by this server.`,
-				Type: NewNonNull(NewList(
-					NewNonNull(DirectiveType),
-				)),
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					if schema, ok := p.Source.(Schema); ok {
-						return schema.Directives(), nil
-					}
-					return nil, nil
-				},
-			},
-		},
-	})
-
-	EnumValueType = NewObject(ObjectConfig{
-		Name: "__EnumValue",
-		Description: "One possible value for a given Enum. Enum values are unique values, not " +
-			"a placeholder for a string or numeric value. However an Enum value is " +
-			"returned in a JSON response as a string.",
-		Fields: Fields{
-			"name": &Field{
-				Type: NewNonNull(String),
-			},
-			"description": &Field{
-				Type: String,
-			},
-			"isDeprecated": &Field{
-				Type: NewNonNull(Boolean),
-				Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-					if field, ok := p.Source.(*EnumValueDefinition); ok {
-						return field.DeprecationReason != "", nil
-					}
-					return false, nil
-				},
-			},
-			"deprecationReason": &Field{
-				Type: String,
-			},
-		},
-	})
-
 	// Again, adding field configs to __Type that have cyclic reference here
 	// because golang don't like them too much during init/compile-time
 	TypeType.AddFieldConfig("fields", &Field{
@@ -628,46 +600,48 @@ func init() {
 	TypeType.AddFieldConfig("ofType", &Field{
 		Type: TypeType,
 	})
+}
 
-	// Note that these are FieldDefinition and not FieldConfig,
-	// so the format for args is different.
-	SchemaMetaFieldDef = &FieldDefinition{
-		Name:        "__schema",
-		Type:        NewNonNull(SchemaType),
-		Description: "Access the current type schema of this server.",
-		Args:        []*Argument{},
-		Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-			return p.Info.Schema, nil
-		},
-	}
-	TypeMetaFieldDef = &FieldDefinition{
-		Name:        "__type",
-		Type:        TypeType,
-		Description: "Request the type information of a single type.",
-		Args: []*Argument{
-			{
-				PrivateName: "name",
-				Type:        NewNonNull(String),
-			},
-		},
-		Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-			name, ok := p.Args["name"].(string)
-			if !ok {
-				return nil, nil
-			}
-			return p.Info.Schema.Type(name), nil
-		},
-	}
+// SchemaMetaFieldDef Meta field definition for Schema
+var SchemaMetaFieldDef = &FieldDefinition{
+	Name:        "__schema",
+	Type:        NewNonNull(SchemaType),
+	Description: "Access the current type schema of this server.",
+	Args:        []*Argument{},
+	Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+		return p.Info.Schema, nil
+	},
+}
 
-	TypeNameMetaFieldDef = &FieldDefinition{
-		Name:        "__typename",
-		Type:        NewNonNull(String),
-		Description: "The name of the current Object type at runtime.",
-		Args:        []*Argument{},
-		Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
-			return p.Info.ParentType.Name(), nil
+// TypeMetaFieldDef Meta field definition for types
+var TypeMetaFieldDef = &FieldDefinition{
+	Name:        "__type",
+	Type:        TypeType,
+	Description: "Request the type information of a single type.",
+	Args: []*Argument{
+		{
+			PrivateName: "name",
+			Type:        NewNonNull(String),
 		},
-	}
+	},
+	Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+		name, ok := p.Args["name"].(string)
+		if !ok {
+			return nil, nil
+		}
+		return p.Info.Schema.Type(name), nil
+	},
+}
+
+// TypeNameMetaFieldDef Meta field definition for type names
+var TypeNameMetaFieldDef = &FieldDefinition{
+	Name:        "__typename",
+	Type:        NewNonNull(String),
+	Description: "The name of the current Object type at runtime.",
+	Args:        []*Argument{},
+	Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
+		return p.Info.ParentType.Name(), nil
+	},
 }
 
 // Produces a GraphQL Value AST given a Golang value.

--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -291,7 +291,6 @@ func (l *Lexer) readString() (Token, error) {
 			break
 		}
 		return makeToken(STRING, start, l.offset, l.sliceBody(blockStart, blockEnd)), nil
-
 	}
 	return makeToken(STRING, start, l.offset, strings.Join(value, "")), nil
 }

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -1,0 +1,79 @@
+package graphql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sprucehealth/graphql"
+)
+
+func TestTracing(t *testing.T) {
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query: graphql.NewObject(graphql.ObjectConfig{
+			Name: "RootQueryType",
+			Fields: graphql.Fields{
+				"object": &graphql.Field{
+					Type: graphql.NewNonNull(graphql.NewObject(graphql.ObjectConfig{
+						Name: "First",
+						Fields: graphql.Fields{
+							"first": &graphql.Field{
+								Type: graphql.NewNonNull(graphql.NewList(graphql.NewObject(graphql.ObjectConfig{
+									Name: "Seconds",
+									Fields: graphql.Fields{
+										"second": &graphql.Field{
+											Type: graphql.Boolean,
+											Resolve: func(ctx context.Context, p graphql.ResolveParams) (any, error) {
+												return true, nil
+											},
+										},
+									},
+								}))),
+								Resolve: func(ctx context.Context, p graphql.ResolveParams) (any, error) {
+									return []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, nil
+								},
+							},
+						},
+					})),
+					Resolve: func(ctx context.Context, p graphql.ResolveParams) (any, error) {
+						return true, nil
+					},
+				},
+			},
+		}),
+	})
+	if err != nil {
+		t.Fatalf("wrong result, unexpected errors: %v", err.Error())
+	}
+	query := "{ object { first { second }} }"
+
+	for range 10 {
+		tr := graphql.NewCountingTracer(true)
+		result := graphql.Do(context.Background(), graphql.Params{
+			Schema:        schema,
+			RequestString: query,
+			Tracer:        tr,
+		})
+		if len(result.Errors) > 0 {
+			t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
+		}
+		var traces []*graphql.TracePathCount
+		for _, tr := range tr.IterTraces() {
+			t.Logf("%s %d executions, %s total duration, %s max duration, %s average duration\n",
+				strings.Join(tr.Path, "."), tr.Count, tr.TotalDuration, tr.MaxDuration, tr.TotalDuration/time.Duration(tr.Count))
+			traces = append(traces, tr)
+		}
+		if len(traces) != 3 {
+			t.Logf("Expected 3 traces, got %d", len(traces))
+		}
+		// Assume the order of execution which should always be consistent unless the executor changes.
+		for i, expCount := range []int{1, 1, 10} {
+			trace := traces[i]
+			if trace.Count != expCount {
+				t.Logf("Expected count of %d for %v, got %d", expCount, trace.Path, trace.Count)
+			}
+		}
+		tr.Recycle()
+	}
+}


### PR DESCRIPTION
Running custom resolvers allows them to pause to do background work or batch requests to dependent serices without actually running concurrently. The use of coroutines is controlled by the "EnableCoroutines" field in "ExecuteParams".