### PR TITLE
Don't use a goroutine for all queries.

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,7 +1,7 @@
 version = '2'
 
 [run]
-go = '1.24'
+go = '1.26'
 
 [linters]
 enable = [

--- a/cmd/graphql2go/client.go
+++ b/cmd/graphql2go/client.go
@@ -38,7 +38,7 @@ func generateClient(g *generator) {
 	g.printf(")\n\n")
 
 	clientTypes := make(map[string]struct{})
-	for _, t := range strings.Split(*flagClientTypes, ",") {
+	for t := range strings.SplitSeq(*flagClientTypes, ",") {
 		clientTypes[t] = struct{}{}
 	}
 

--- a/cmd/graphql2go/directives.go
+++ b/cmd/graphql2go/directives.go
@@ -39,6 +39,8 @@ parser:
 		case tokComma:
 		case tokIllegal:
 			return "", nil, fmt.Errorf("bad token at %d in %q", p, ds)
+		case tokString:
+			break parser
 		default:
 			break parser
 		}

--- a/cmd/graphql2go/main.go
+++ b/cmd/graphql2go/main.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -138,7 +140,11 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to create output file: %s", err)
 		}
-		defer fo.Close()
+		defer func() {
+			if err := fo.Close(); err != nil {
+				log.Fatalf("Failed to close output file: %s", err)
+			}
+		}()
 		outWriter = fo
 	}
 
@@ -286,9 +292,7 @@ func newGenerator(outWriter io.Writer, root *ast.Document) *generator {
 		if err := json.Unmarshal(b, &g.cfg); err != nil {
 			log.Fatalf("Failed to decode config file: %s", err)
 		}
-		for k, v := range g.cfg.Initialisms {
-			initialisms[k] = v
-		}
+		maps.Copy(initialisms, g.cfg.Initialisms)
 	}
 
 	// Generate index of type name to definition and make sure all names are unique
@@ -935,12 +939,7 @@ func (g *generator) genObjectModel(def *ast.ObjectDefinition) {
 }
 
 func (g *generator) hasCustomResolver(typeName, fieldName string) bool {
-	for _, f := range g.cfg.Resolvers[typeName] {
-		if f == fieldName {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(g.cfg.Resolvers[typeName], fieldName)
 }
 
 func isTopLevelObject(o string) bool {

--- a/definition.go
+++ b/definition.go
@@ -165,8 +165,7 @@ func IsAbstractType(ttype any) bool {
 }
 
 // Nullable interface for types that can accept null as a value.
-type Nullable interface {
-}
+type Nullable any
 
 var _ Nullable = (*Scalar)(nil)
 var _ Nullable = (*Object)(nil)

--- a/examples/context/main.go
+++ b/examples/context/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/sprucehealth/graphql"
 )
 
+type currentUserCtxKey struct{}
+
 var Schema graphql.Schema
 
 var userType = graphql.NewObject(
@@ -33,7 +35,7 @@ var queryType = graphql.NewObject(
 			"me": &graphql.Field{
 				Type: userType,
 				Resolve: func(ctx context.Context, p graphql.ResolveParams) (any, error) {
-					return ctx.Value("currentUser"), nil
+					return ctx.Value(currentUserCtxKey{}), nil
 				},
 			},
 		},
@@ -44,7 +46,7 @@ func graphqlHandler(w http.ResponseWriter, r *http.Request) {
 		ID   int    `json:"id"`
 		Name string `json:"name"`
 	}{1, "cool user"}
-	result := graphql.Do(context.WithValue(r.Context(), "currentUser", user), graphql.Params{
+	result := graphql.Do(context.WithValue(r.Context(), currentUserCtxKey{}, user), graphql.Params{
 		Schema:        Schema,
 		RequestString: r.URL.Query()["query"][0],
 	})
@@ -52,14 +54,14 @@ func graphqlHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("wrong result, unexpected errors: %v", result.Errors)
 		return
 	}
-	json.NewEncoder(w).Encode(result)
+	_ = json.NewEncoder(w).Encode(result)
 }
 
 func main() {
 	http.HandleFunc("/graphql", graphqlHandler)
 	fmt.Println("Now server is running on port 8080")
 	fmt.Println("Test with Get      : curl -g 'http://localhost:8080/graphql?query={me{id,name}}'")
-	http.ListenAndServe(":8080", nil)
+	_ = http.ListenAndServe(":8080", nil)
 }
 
 func init() {

--- a/executor.go
+++ b/executor.go
@@ -31,71 +31,39 @@ type ExecuteParams struct {
 	Tracer      Tracer
 }
 
-func Execute(ctx context.Context, p ExecuteParams) *Result {
-	resultChannel := make(chan *Result, 1)
-
-	go func(out chan<- *Result) {
-		result := &Result{}
-
-		exeContext, err := buildExecutionContext(BuildExecutionCtxParams{
-			Schema:                          p.Schema,
-			Root:                            p.Root,
-			AST:                             p.AST,
-			OperationName:                   p.OperationName,
-			Args:                            p.Args,
-			Errors:                          nil,
-			Result:                          result,
-			DeprecatedFieldFn:               p.DeprecatedFieldFn,
-			FieldDefinitionDirectiveHandler: p.FieldDefinitionDirectiveHandler,
-			DisallowIntrospection:           p.DisallowIntrospection,
-			Tracer:                          p.Tracer,
-			EnableCoroutines:                p.EnableCoroutines,
-		})
-
-		if err != nil {
-			result.Errors = append(result.Errors, gqlerrors.FormatError(err))
-			out <- result
-			return
-		}
-
-		defer func() {
-			if r := recover(); r != nil {
-				err := gqlerrors.FormatPanic(r)
-				exeContext.Errors = append(exeContext.Errors, gqlerrors.FormatError(err))
-				result.Errors = exeContext.Errors
-			}
-			out <- result
-		}()
-
-		result = executeOperation(ctx, ExecuteOperationParams{
-			ExecutionContext: exeContext,
-			Root:             p.Root,
-			Operation:        exeContext.Operation,
-		})
-	}(resultChannel)
-
-	var result *Result
-	select {
-	case r := <-resultChannel:
-		result = r
-	case <-ctx.Done():
-		err := ctx.Err()
-		// Give the executor some extra time to complete. Hopefully, we can
-		// get a better error showing where the execution timed out.
-		if errors.Is(err, context.DeadlineExceeded) && p.TimeoutWait != 0 {
-			select {
-			case r := <-resultChannel:
-				result = r
-			case <-time.After(p.TimeoutWait):
-			}
-		}
-		if result == nil {
-			result = &Result{
-				Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(err)},
-			}
-		}
+func Execute(ctx context.Context, p ExecuteParams) (result *Result) {
+	exeContext, err := buildExecutionContext(BuildExecutionCtxParams{
+		Schema:                          p.Schema,
+		Root:                            p.Root,
+		AST:                             p.AST,
+		OperationName:                   p.OperationName,
+		Args:                            p.Args,
+		Errors:                          nil,
+		Result:                          result,
+		DeprecatedFieldFn:               p.DeprecatedFieldFn,
+		FieldDefinitionDirectiveHandler: p.FieldDefinitionDirectiveHandler,
+		DisallowIntrospection:           p.DisallowIntrospection,
+		Tracer:                          p.Tracer,
+		EnableCoroutines:                p.EnableCoroutines,
+	})
+	if err != nil {
+		return &Result{Errors: []gqlerrors.FormattedError{gqlerrors.FormatError(err)}}
 	}
-	return result
+
+	result = &Result{}
+	defer func() {
+		if r := recover(); r != nil {
+			err := gqlerrors.FormatPanic(r)
+			exeContext.Errors = append(exeContext.Errors, gqlerrors.FormatError(err))
+			result.Errors = exeContext.Errors
+		}
+	}()
+
+	return executeOperation(ctx, ExecuteOperationParams{
+		ExecutionContext: exeContext,
+		Root:             p.Root,
+		Operation:        exeContext.Operation,
+	})
 }
 
 type BuildExecutionCtxParams struct {
@@ -159,7 +127,7 @@ func buildExecutionContext(p BuildExecutionCtxParams) (*ExecutionContext, error)
 				operation = definition
 			}
 		case *ast.FragmentDefinition:
-			key := ""
+			var key string
 			if definition.GetName() != nil && definition.GetName().Value != "" {
 				key = definition.GetName().Value
 			}
@@ -954,7 +922,7 @@ func defaultResolveFn(ctx context.Context, p ResolveParams) (any, error) {
 
 	// try to resolve p.Source as a struct first
 	sourceVal := reflect.ValueOf(p.Source)
-	if sourceVal.IsValid() && sourceVal.Type().Kind() == reflect.Ptr {
+	if sourceVal.IsValid() && sourceVal.Type().Kind() == reflect.Pointer {
 		sourceVal = sourceVal.Elem()
 	}
 	if !sourceVal.IsValid() {

--- a/executor_test.go
+++ b/executor_test.go
@@ -7,13 +7,10 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/sprucehealth/graphql"
 	"github.com/sprucehealth/graphql/gqlerrors"
 	"github.com/sprucehealth/graphql/language/location"
-	"github.com/sprucehealth/graphql/language/parser"
-	"github.com/sprucehealth/graphql/language/source"
 	"github.com/sprucehealth/graphql/testutil"
 )
 
@@ -1817,151 +1814,19 @@ func TestGraphqlTag(t *testing.T) {
 	}
 }
 
-func TestContextDeadline(t *testing.T) {
-	timeout := time.Millisecond * time.Duration(100)
-	acceptableDelay := time.Millisecond * time.Duration(10)
-	expectedErrors := []gqlerrors.FormattedError{
-		{
-			Message:   context.DeadlineExceeded.Error(),
-			Locations: []location.SourceLocation{},
-			Type:      "INTERNAL",
-		},
-	}
-
-	// Query type includes a field that won't resolve within the deadline
-	var queryType = graphql.NewObject(
-		graphql.ObjectConfig{
-			Name: "Query",
-			Fields: graphql.Fields{
-				"hello": &graphql.Field{
-					Type: graphql.String,
-					Resolve: func(ctx context.Context, p graphql.ResolveParams) (any, error) {
-						time.Sleep(2 * time.Second)
-						return "world", nil
-					},
-				},
-			},
-		})
-	schema, err := graphql.NewSchema(graphql.SchemaConfig{
-		Query: queryType,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error, got: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	startTime := time.Now()
-	result := graphql.Do(ctx, graphql.Params{
-		Schema:        schema,
-		RequestString: "{hello}",
-	})
-	duration := time.Since(startTime)
-
-	if duration > timeout+acceptableDelay {
-		t.Fatalf("graphql.Do completed in %s, should have completed in %s", duration, timeout)
-	}
-	if !result.HasErrors() || len(result.Errors) == 0 {
-		t.Fatalf("Result should include errors when deadline is exceeded")
-	}
-	result.Errors[0].OriginalError = nil
-	result.Errors[0].StackTrace = ""
-	if !reflect.DeepEqual(expectedErrors, result.Errors) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
-	}
-}
-
-func TestContextDeadlineWait(t *testing.T) {
-	timeout := time.Millisecond * time.Duration(100)
-	acceptableDelay := time.Millisecond * time.Duration(10)
-	expectedErrors := []gqlerrors.FormattedError{
-		{
-			Message:   context.DeadlineExceeded.Error(),
-			Locations: []location.SourceLocation{},
-			Type:      "INTERNAL",
-		},
-	}
-
-	// Query type includes a field that won't resolve within the deadline
-	var queryType = graphql.NewObject(
-		graphql.ObjectConfig{
-			Name: "Query",
-			Fields: graphql.Fields{
-				"hello": &graphql.Field{
-					Type: graphql.String,
-					Resolve: func(ctx context.Context, p graphql.ResolveParams) (any, error) {
-						<-ctx.Done()
-						return nil, fmt.Errorf("Resolvers: %w", ctx.Err())
-					},
-				},
-			},
-		})
-	schema, err := graphql.NewSchema(graphql.SchemaConfig{
-		Query: queryType,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error, got: %v", err)
-	}
-
-	// 0 timeout wait
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	startTime := time.Now()
-	result := graphql.Do(ctx, graphql.Params{
-		Schema:        schema,
-		RequestString: "{hello}",
-	})
-	duration := time.Since(startTime)
-
-	if duration > timeout+acceptableDelay {
-		t.Fatalf("graphql.Do completed in %s, should have completed in %s", duration, timeout)
-	}
-	if !result.HasErrors() || len(result.Errors) == 0 {
-		t.Fatalf("Result should include errors when deadline is exceeded")
-	}
-	result.Errors[0].OriginalError = nil
-	result.Errors[0].StackTrace = ""
-	if !reflect.DeepEqual(expectedErrors, result.Errors) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
-	}
-
-	// >0 second timeout wait
-
-	ctx, cancel = context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	startTime = time.Now()
-	ast, err := parser.Parse(parser.ParseParams{Source: source.New("GraphQL request", "{hello}")})
-	if err != nil {
-		t.Fatal(err)
-	}
-	result = graphql.Execute(ctx, graphql.ExecuteParams{
-		Schema:      schema,
-		AST:         ast,
-		TimeoutWait: time.Second,
-	})
-	duration = time.Since(startTime)
-
-	if duration > timeout+acceptableDelay {
-		t.Fatalf("graphql.Do completed in %s, should have completed in %s", duration, timeout)
-	}
-	if !result.HasErrors() || len(result.Errors) == 0 {
-		t.Fatalf("Result should include errors when deadline is exceeded")
-	}
-	if result.Errors[0].Error() != "Resolvers: context deadline exceeded" {
-		t.Fatalf("Unexpected 'Resolvers: context deadline exceeded' got '%s'", result.Errors[0].Error())
-	}
-}
-
 func TestContextCancel(t *testing.T) {
 	expectedErrors := []gqlerrors.FormattedError{
 		{
-			Message:   context.Canceled.Error(),
-			Locations: []location.SourceLocation{},
-			Type:      "INTERNAL",
+			Message:       context.Canceled.Error(),
+			Locations:     []location.SourceLocation{},
+			Type:          "INTERNAL",
+			OriginalError: context.Canceled,
+		},
+		{
+			Message:       context.Canceled.Error(),
+			Locations:     []location.SourceLocation{},
+			Type:          "INTERNAL",
+			OriginalError: context.Canceled,
 		},
 	}
 
@@ -2007,13 +1872,13 @@ func TestContextCancel(t *testing.T) {
 	if !result.HasErrors() || len(result.Errors) == 0 {
 		t.Fatalf("Result should include errors when deadline is exceeded")
 	}
-	result.Errors[0].OriginalError = nil
-	result.Errors[0].StackTrace = ""
-	if !reflect.DeepEqual(expectedErrors, result.Errors) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
-	}
 	if resolveCount != 1 {
 		t.Fatalf("Expected only 1 resolver to be called")
+	}
+	result.Errors[0].StackTrace = ""
+	result.Errors[1].StackTrace = ""
+	if !reflect.DeepEqual(expectedErrors, result.Errors) {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
 	}
 }
 
@@ -2143,7 +2008,9 @@ func TestCoroutines(t *testing.T) {
 				"foo": &graphql.Field{
 					Type: graphql.NewNonNull(graphql.String),
 					Resolve: func(ctx context.Context, p graphql.ResolveParams) (any, error) {
-						graphql.PauseCoroutine(ctx)
+						if err := graphql.PauseCoroutine(ctx); err != nil {
+							t.Fatal(err)
+						}
 						return "bar", nil
 					},
 				},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sprucehealth/graphql
 
-go 1.25
+go 1.26
 
 require github.com/kr/pretty v0.3.1
 

--- a/gqldecode/gqldecode.go
+++ b/gqldecode/gqldecode.go
@@ -46,7 +46,7 @@ func Decode(in map[string]any, out any) (err error) {
 		}
 	}()
 	outV := reflect.ValueOf(out)
-	if outV.Kind() != reflect.Ptr || outV.Type().Elem().Kind() != reflect.Struct {
+	if outV.Kind() != reflect.Pointer || outV.Type().Elem().Kind() != reflect.Struct {
 		return errors.New("gqldecode: Decode requires a pointer to a struct")
 	}
 	decodeStruct(in, outV.Elem())
@@ -67,7 +67,7 @@ func decodeStruct(in map[string]any, out reflect.Value) {
 
 func decodeValue(v any, out reflect.Value, fi *structFieldInfo) {
 	if fi.hasDecoderMethod || fi.hasNonPtrDecoderMethod {
-		if out.Kind() == reflect.Ptr && out.IsNil() {
+		if out.Kind() == reflect.Pointer && out.IsNil() {
 			out.Set(reflect.New(out.Type().Elem()))
 		}
 
@@ -82,6 +82,7 @@ func decodeValue(v any, out reflect.Value, fi *structFieldInfo) {
 		}
 		return
 	}
+	//nolint:exhaustive
 	switch out.Kind() {
 	case reflect.String:
 		s, ok := v.(string)
@@ -163,12 +164,12 @@ func decodeValue(v any, out reflect.Value, fi *structFieldInfo) {
 		switch {
 		case out.Type() == reflect.TypeOf(v):
 			out.Set(reflect.ValueOf(v))
-		case reflect.ValueOf(v).Kind() == reflect.Ptr && out.Type() == reflect.TypeOf(v).Elem():
+		case reflect.ValueOf(v).Kind() == reflect.Pointer && out.Type() == reflect.TypeOf(v).Elem():
 			out.Set(reflect.ValueOf(v).Elem())
 		default:
 			decodeStruct(v.(map[string]any), out)
 		}
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if out.IsNil() {
 			out.Set(reflect.New(out.Type().Elem()))
 		}
@@ -220,7 +221,7 @@ func infoForStruct(structType reflect.Type) *structInfo {
 	sm = &structInfo{
 		fields: make(map[string]*structFieldInfo),
 	}
-	decoderType := reflect.TypeOf((*Decoder)(nil)).Elem()
+	decoderType := reflect.TypeFor[Decoder]()
 	for i := 0; i < structType.NumField(); i++ {
 		field := structType.Field(i)
 		if field.PkgPath != "" && !field.Anonymous {

--- a/gqlerrors/error.go
+++ b/gqlerrors/error.go
@@ -1,8 +1,6 @@
 package gqlerrors
 
 import (
-	"errors"
-
 	"github.com/sprucehealth/graphql/language/ast"
 	"github.com/sprucehealth/graphql/language/location"
 	"github.com/sprucehealth/graphql/language/source"
@@ -55,7 +53,7 @@ func NewError(typ ErrorType, message string, nodes []ast.Node, stack string, sou
 			positions = append(positions, node.GetLoc().Start)
 		}
 	}
-	locations := []location.SourceLocation{}
+	locations := make([]location.SourceLocation, 0, len(positions))
 	for _, pos := range positions {
 		loc := location.GetLocation(source, pos)
 		locations = append(locations, loc)
@@ -70,10 +68,4 @@ func NewError(typ ErrorType, message string, nodes []ast.Node, stack string, sou
 		Locations:     locations,
 		OriginalError: origError,
 	}
-}
-
-func asType[T error](err error) (T, bool) {
-	var tp T
-	ok := errors.As(err, &tp)
-	return tp, ok
 }

--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -26,13 +26,13 @@ func NewFormattedError(message string) FormattedError {
 }
 
 func FormatError(err error) FormattedError {
-	if e, ok := asType[FormattedError](err); ok {
+	if e, ok := errors.AsType[FormattedError](err); ok {
 		return e
 	}
-	if e, ok := asType[*FormattedError](err); ok {
+	if e, ok := errors.AsType[*FormattedError](err); ok {
 		return *e
 	}
-	if e, ok := asType[runtime.Error](err); ok {
+	if e, ok := errors.AsType[runtime.Error](err); ok {
 		return FormattedError{
 			Message:       e.Error(),
 			Type:          ErrorTypeInternal,
@@ -40,7 +40,7 @@ func FormatError(err error) FormattedError {
 			OriginalError: e,
 		}
 	}
-	if e, ok := asType[*Error](err); ok {
+	if e, ok := errors.AsType[*Error](err); ok {
 		return FormattedError{
 			Type:          e.Type,
 			Message:       e.Error(),
@@ -48,7 +48,7 @@ func FormatError(err error) FormattedError {
 			OriginalError: e.OriginalError,
 		}
 	}
-	if e, ok := asType[Error](err); ok {
+	if e, ok := errors.AsType[Error](err); ok {
 		return FormattedError{
 			Type:          e.Type,
 			Message:       e.Error(),
@@ -66,18 +66,22 @@ func FormatError(err error) FormattedError {
 }
 
 func FormatPanic(r any) FormattedError {
-	if e, ok := r.(FormattedError); ok {
-		return e
+	err, ok := r.(error)
+	if ok {
+		if e, ok := errors.AsType[FormattedError](err); ok {
+			return e
+		}
 	}
 	return FormattedError{
-		Message:    fmt.Sprintf("panic %v", r),
-		Type:       ErrorTypeInternal,
-		StackTrace: stackTrace(),
+		Message:       fmt.Sprintf("panic %v", r),
+		Type:          ErrorTypeInternal,
+		StackTrace:    stackTrace(),
+		OriginalError: err,
 	}
 }
 
 func FormatErrors(errs ...error) []FormattedError {
-	formattedErrors := []FormattedError{}
+	formattedErrors := make([]FormattedError, 0, len(errs))
 	for _, err := range errs {
 		formattedErrors = append(formattedErrors, FormatError(err))
 	}

--- a/gqlerrors/syntax.go
+++ b/gqlerrors/syntax.go
@@ -49,25 +49,25 @@ func highlightSourceAtLocation(s *source.Source, l location.SourceLocation) stri
 	nextLineNum := strconv.Itoa(line + 1)
 	padLen := len(nextLineNum)
 	lines := regexp.MustCompile("\r\n|[\n\r]").Split(s.Body(), -1)
-	var highlight string
+	var highlight strings.Builder
 	if line >= 2 {
-		highlight += fmt.Sprintf("%s: %s\n", lpad(padLen, prevLineNum), printLine(lines[line-2]))
+		_, _ = fmt.Fprintf(&highlight, "%s: %s\n", lpad(padLen, prevLineNum), printLine(lines[line-2]))
 	}
-	highlight += fmt.Sprintf("%s: %s\n", lpad(padLen, lineNum), printLine(lines[line-1]))
+	_, _ = fmt.Fprintf(&highlight, "%s: %s\n", lpad(padLen, lineNum), printLine(lines[line-1]))
 	for i := 1; i < (2 + padLen + l.Column); i++ {
-		highlight += " "
+		highlight.WriteString(" ")
 	}
-	highlight += "^\n"
+	highlight.WriteString("^\n")
 	if line < len(lines) {
-		highlight += fmt.Sprintf("%s: %s\n", lpad(padLen, nextLineNum), printLine(lines[line]))
+		_, _ = fmt.Fprintf(&highlight, "%s: %s\n", lpad(padLen, nextLineNum), printLine(lines[line]))
 	}
-	return highlight
+	return highlight.String()
 }
 
 func lpad(l int, s string) string {
-	var r string
+	var r strings.Builder
 	for i := 1; i < (l - len(s) + 1); i++ {
-		r += " "
+		r.WriteString(" ")
 	}
-	return r + s
+	return r.String() + s
 }

--- a/introspection.go
+++ b/introspection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 
@@ -360,13 +361,7 @@ var DirectiveType = NewObject(ObjectConfig{
 			Type:              NewNonNull(Boolean),
 			Resolve: func(ctx context.Context, p ResolveParams) (any, error) {
 				if dir, ok := p.Source.(*Directive); ok {
-					res := false
-					for _, loc := range dir.Locations {
-						if loc == DirectiveLocationField {
-							res = true
-							break
-						}
-					}
+					res := slices.Contains(dir.Locations, DirectiveLocationField)
 					return res, nil
 				}
 				return false, nil
@@ -671,7 +666,7 @@ func astFromValue(value any, ttype Type) ast.Value {
 	if !valueVal.IsValid() {
 		return nil
 	}
-	if valueVal.Type().Kind() == reflect.Ptr {
+	if valueVal.Type().Kind() == reflect.Pointer {
 		valueVal = valueVal.Elem()
 	}
 	if !valueVal.IsValid() {

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -994,9 +995,9 @@ func checkError(t *testing.T, err error, expectedError *gqlerrors.Error) {
 	if err.Error() != expectedError.Message {
 		t.Fatalf("unexpected error.\nexpected:\n%v\n\ngot:\n%v", expectedError, err.Error())
 	}
-	gErr := toError(err)
-	if gErr == nil {
-		t.Fatalf("unexpected nil Error")
+	gErr, ok := errors.AsType[*gqlerrors.Error](err)
+	if !ok {
+		t.Fatalf("unexpected *gqlerrors.Error got %T", err)
 	}
 	if len(expectedError.Positions) > 0 && !reflect.DeepEqual(gErr.Positions, expectedError.Positions) {
 		t.Fatalf("unexpected Error.Positions.\nexpected:\n%v\n\ngot:\n%v", expectedError.Positions, gErr.Positions)
@@ -1016,18 +1017,6 @@ func checkErrorMessage(t *testing.T, err error, expectedMessage string) {
 		if lines[0] != expectedMessage {
 			t.Fatalf("unexpected error.\nexpected:\n%v\n\ngot:\n%v", expectedMessage, lines[0])
 		}
-	}
-}
-
-func toError(err error) *gqlerrors.Error {
-	if err == nil {
-		return nil
-	}
-	switch err := err.(type) {
-	case *gqlerrors.Error:
-		return err
-	default:
-		return nil
 	}
 }
 

--- a/language/printer/printer.go
+++ b/language/printer/printer.go
@@ -45,7 +45,7 @@ func (w *walker) walkASTSlice(sl any) []string {
 	v := reflect.ValueOf(sl)
 	n := v.Len()
 	strs := make([]string, 0, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		s := w.walkAST(v.Index(i).Interface().(ast.Node))
 		if s != "" {
 			strs = append(strs, s)

--- a/rules.go
+++ b/rules.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 
@@ -495,13 +496,7 @@ func KnownDirectivesRule(context *ValidationContext) *ValidationRuleInstance {
 
 				candidateLocation := getDirectiveLocationForASTPath(p.Ancestors)
 
-				directiveHasLocation := false
-				for _, loc := range directiveDef.Locations {
-					if loc == candidateLocation {
-						directiveHasLocation = true
-						break
-					}
-				}
+				directiveHasLocation := slices.Contains(directiveDef.Locations, candidateLocation)
 
 				if candidateLocation == "" {
 					context.ReportError(newValidationError(

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -80,7 +80,7 @@ func init() {
 		PrimaryFunction: "Astromech",
 	}
 	Luke.Friends = append(Luke.Friends, []StarWarsChar{Han, Leia, Threepio, Artoo}...)
-	Vader.Friends = append(Luke.Friends, []StarWarsChar{Tarkin}...)
+	Vader.Friends = append(Vader.Friends, []StarWarsChar{Tarkin}...)
 	Han.Friends = append(Han.Friends, []StarWarsChar{Luke, Leia, Artoo}...)
 	Leia.Friends = append(Leia.Friends, []StarWarsChar{Luke, Han, Threepio, Artoo}...)
 	Tarkin.Friends = append(Tarkin.Friends, []StarWarsChar{Vader}...)
@@ -238,13 +238,13 @@ func init() {
 				Description: "The friends of the droid, or an empty list if they have none.",
 				Resolve: func(ctx context.Context, p graphql.ResolveParams) (any, error) {
 					if droid, ok := p.Source.(StarWarsChar); ok {
-						//friends := []map[string]any{}
-						//for _, friend := range droid.Friends {
+						// friends := []map[string]any{}
+						// for _, friend := range droid.Friends {
 						//	friends = append(friends, map[string]any{
 						//		"name": friend.Name,
 						//		"id":   friend.ID,
 						//	})
-						//}
+						// }
 						return droid.Friends, nil
 					}
 					return []any{}, nil

--- a/union_interface_test.go
+++ b/union_interface_test.go
@@ -9,10 +9,8 @@ import (
 	"github.com/sprucehealth/graphql/testutil"
 )
 
-type testNamedType interface {
-}
-type testPet interface {
-}
+type testNamedType any
+type testPet any
 type testDog2 struct {
 	Name  string `json:"name"`
 	Barks bool   `json:"barks"`

--- a/values.go
+++ b/values.go
@@ -240,7 +240,7 @@ func isValidInputValue(value any, ttype Input) (bool, []string) {
 	case *List:
 		itemType := ttype.OfType
 		valType := reflect.ValueOf(value)
-		if valType.Kind() == reflect.Ptr {
+		if valType.Kind() == reflect.Pointer {
 			valType = valType.Elem()
 		}
 		if valType.Kind() == reflect.Slice {
@@ -325,7 +325,7 @@ func isNullish(value any) bool {
 		return math.IsNaN(v)
 	}
 	// The any can hide an underlying nil ptr
-	if v := reflect.ValueOf(value); v.Kind() == reflect.Ptr {
+	if v := reflect.ValueOf(value); v.Kind() == reflect.Pointer {
 		return v.IsNil()
 	}
 	return false
@@ -343,7 +343,7 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Pointer:
 		return v.IsNil()
 	case reflect.Complex64, reflect.Complex128:
 		return v.Complex() == 0


### PR DESCRIPTION
Remove the goroutine that wrapped the executor to provide context handling. It's better for the caller to do the wrapping if desired. This has the benefit of also returning propery traced errors where appropriate. The executor also still checks the context before running each resolver to catch context errors if the resolver doesn't. It's possible for the resolver to take along time and miss the deadline, but nearly always it'll be a network request that's slow which will have a context attached. If the user of the library cares about always strictly handling the deadline then the call can be wrapped. This gives more control.